### PR TITLE
Removing the master-slave phrasing

### DIFF
--- a/env/Lib/site-packages/OpenSSL/SSL.py
+++ b/env/Lib/site-packages/OpenSSL/SSL.py
@@ -2154,9 +2154,9 @@ class Connection(object):
         _lib.SSL_get_client_random(self._ssl, outp, length)
         return _ffi.buffer(outp, length)[:]
 
-    def master_key(self):
+    def main_key(self):
         """
-        Retrieve the value of the master key for this session.
+        Retrieve the value of the main key for this session.
 
         :return: A string representing the state
         """
@@ -2164,10 +2164,10 @@ class Connection(object):
         if session == _ffi.NULL:
             return None
 
-        length = _lib.SSL_SESSION_get_master_key(session, _ffi.NULL, 0)
+        length = _lib.SSL_SESSION_get_main_key(session, _ffi.NULL, 0)
         assert length > 0
         outp = _no_zero_allocator("unsigned char[]", length)
-        _lib.SSL_SESSION_get_master_key(session, outp, length)
+        _lib.SSL_SESSION_get_main_key(session, outp, length)
         return _ffi.buffer(outp, length)[:]
 
     def export_keying_material(self, label, olen, context=None):

--- a/env/Lib/site-packages/apitools/base/py/batch.py
+++ b/env/Lib/site-packages/apitools/base/py/batch.py
@@ -179,7 +179,7 @@ class BatchApiRequest(object):
             method_config, request, global_params=global_params,
             upload_config=upload_config)
 
-        # Create the request and add it to our master list.
+        # Create the request and add it to our main list.
         api_request = self.ApiCall(
             http_request, self.retryable_codes, service, method_config)
         self.api_requests.append(api_request)

--- a/env/Lib/site-packages/boto/elastictranscoder/layer1.py
+++ b/env/Lib/site-packages/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/env/Lib/site-packages/boto/emr/connection.py
+++ b/env/Lib/site-packages/boto/emr/connection.py
@@ -408,8 +408,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -436,11 +436,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -471,7 +471,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -526,15 +526,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -721,15 +721,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/env/Lib/site-packages/boto/emr/step.py
+++ b/env/Lib/site-packages/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/env/Lib/site-packages/boto/kms/layer1.py
+++ b/env/Lib/site-packages/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/env/Lib/site-packages/boto/opsworks/layer1.py
+++ b/env/Lib/site-packages/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/env/Lib/site-packages/boto/pyami/bootstrap.py
+++ b/env/Lib/site-packages/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/env/Lib/site-packages/boto/rds/__init__.py
+++ b/env/Lib/site-packages/boto/rds/__init__.py
@@ -138,8 +138,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -168,8 +168,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -222,8 +222,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -240,8 +240,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -398,8 +398,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -423,8 +423,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -562,7 +562,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -593,8 +593,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -680,8 +680,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/env/Lib/site-packages/boto/rds/dbinstance.py
+++ b/env/Lib/site-packages/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/env/Lib/site-packages/boto/rds/dbsnapshot.py
+++ b/env/Lib/site-packages/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/env/Lib/site-packages/boto/rds2/layer1.py
+++ b/env/Lib/site-packages/boto/rds2/layer1.py
@@ -321,8 +321,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -417,9 +417,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -452,8 +452,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -536,7 +536,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -656,8 +656,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2488,7 +2488,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2616,14 +2616,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2634,7 +2634,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2668,7 +2668,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2820,8 +2820,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/env/Lib/site-packages/boto/redshift/layer1.py
+++ b/env/Lib/site-packages/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/env/Lib/site-packages/gslib/addlhelp/naming.py
+++ b/env/Lib/site-packages/gslib/addlhelp/naming.py
@@ -97,8 +97,8 @@ _DETAILED_HELP_TEXT = ("""
   user who creates the bucket, so the user who creates the bucket must
   also be verified as an owner or manager of the domain.
 
-  To verify as the owner or manager of a domain, use the Google Webmaster
-  Tools verification process. The Webmaster Tools verification process
+  To verify as the owner or manager of a domain, use the Google Webmain
+  Tools verification process. The Webmain Tools verification process
   provides three methods for verifying an owner or manager of a domain:
 
   1. Adding a special Meta tag to a site's homepage.

--- a/env/Lib/site-packages/gslib/commands/notification.py
+++ b/env/Lib/site-packages/gslib/commands/notification.py
@@ -343,7 +343,7 @@ which is not authorized for your project. Please ensure that you are using
 Service Account authentication and that the Service Account's project is
 authorized for the application URL. Notification endpoint URLs must also be
 whitelisted in your Cloud Console project. To do that, the domain must also be
-verified using Google Webmaster Tools. For instructions, please see
+verified using Google Webmain Tools. For instructions, please see
 `Notification Authorization
 <https://cloud.google.com/storage/docs/object-change-notification#_Authorization>`_.
 """

--- a/env/Lib/site-packages/gslib/ui_controller.py
+++ b/env/Lib/site-packages/gslib/ui_controller.py
@@ -1084,7 +1084,7 @@ class UIController(object):
 
 
 class MainThreadUIQueue(object):
-  """Handles status display and processing in the main thread / master process.
+  """Handles status display and processing in the main thread / main process.
 
   This class emulates a queue to cover main-thread activity before or after
   Apply, as well as for the single-threaded, single-process case, i.e.,

--- a/env/Lib/site-packages/gslib/vendored/boto/boto/elastictranscoder/layer1.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/boto/elastictranscoder/layer1.py
@@ -118,10 +118,10 @@ class ElasticTranscoderConnection(AWSAuthConnection):
         :type playlists: list
         :param playlists: If you specify a preset in `PresetId` for which the
             value of `Container` is ts (MPEG-TS), Playlists contains
-            information about the master playlists that you want Elastic
+            information about the main playlists that you want Elastic
             Transcoder to create.
-        We recommend that you create only one master playlist. The maximum
-            number of master playlists in a job is 30.
+        We recommend that you create only one main playlist. The maximum
+            number of main playlists in a job is 30.
 
         """
         uri = '/2012-09-25/jobs'

--- a/env/Lib/site-packages/gslib/vendored/boto/boto/emr/connection.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/boto/emr/connection.py
@@ -408,8 +408,8 @@ class EmrConnection(AWSQueryConnection):
 
     def run_jobflow(self, name, log_uri=None, ec2_keyname=None,
                     availability_zone=None,
-                    master_instance_type='m1.small',
-                    slave_instance_type='m1.small', num_instances=1,
+                    main_instance_type='m1.small',
+                    subordinate_instance_type='m1.small', num_instances=1,
                     action_on_failure='TERMINATE_JOB_FLOW', keep_alive=False,
                     enable_debugging=False,
                     hadoop_version=None,
@@ -436,11 +436,11 @@ class EmrConnection(AWSQueryConnection):
         :type availability_zone: str
         :param availability_zone: EC2 availability zone of the cluster
 
-        :type master_instance_type: str
-        :param master_instance_type: EC2 instance type of the master
+        :type main_instance_type: str
+        :param main_instance_type: EC2 instance type of the main
 
-        :type slave_instance_type: str
-        :param slave_instance_type: EC2 instance type of the slave nodes
+        :type subordinate_instance_type: str
+        :param subordinate_instance_type: EC2 instance type of the subordinate nodes
 
         :type num_instances: int
         :param num_instances: Number of instances in the Hadoop cluster
@@ -471,7 +471,7 @@ class EmrConnection(AWSQueryConnection):
         :param instance_groups: Optional list of instance groups to
             use when creating this job.
             NB: When provided, this argument supersedes num_instances
-            and master/slave_instance_type.
+            and main/subordinate_instance_type.
 
         :type ami_version: str
         :param ami_version: Amazon Machine Image (AMI) version to use
@@ -526,15 +526,15 @@ class EmrConnection(AWSQueryConnection):
         params.update(common_params)
 
         # NB: according to the AWS API's error message, we must
-        # "configure instances either using instance count, master and
-        # slave instance type or instance groups but not both."
+        # "configure instances either using instance count, main and
+        # subordinate instance type or instance groups but not both."
         #
         # Thus we switch here on the truthiness of instance_groups.
         if not instance_groups:
             # Instance args (the common case)
             instance_params = self._build_instance_count_and_type_args(
-                                                        master_instance_type,
-                                                        slave_instance_type,
+                                                        main_instance_type,
+                                                        subordinate_instance_type,
                                                         num_instances)
             params.update(instance_params)
         else:
@@ -721,15 +721,15 @@ class EmrConnection(AWSQueryConnection):
 
         return params
 
-    def _build_instance_count_and_type_args(self, master_instance_type,
-                                            slave_instance_type, num_instances):
+    def _build_instance_count_and_type_args(self, main_instance_type,
+                                            subordinate_instance_type, num_instances):
         """
-        Takes a master instance type (string), a slave instance type
+        Takes a main instance type (string), a subordinate instance type
         (string), and a number of instances. Returns a comparable dict
         for use in making a RunJobFlow request.
         """
-        params = {'Instances.MasterInstanceType': master_instance_type,
-                  'Instances.SlaveInstanceType': slave_instance_type,
+        params = {'Instances.MainInstanceType': main_instance_type,
+                  'Instances.SubordinateInstanceType': subordinate_instance_type,
                   'Instances.InstanceCount': num_instances}
         return params
 

--- a/env/Lib/site-packages/gslib/vendored/boto/boto/emr/step.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/boto/emr/step.py
@@ -132,7 +132,7 @@ class StreamingStep(Step):
         :param output: The output uri
         :type jar: str
         :param jar: The hadoop streaming jar. This can be either a local
-            path on the master node, or an s3:// URI.
+            path on the main node, or an s3:// URI.
         """
         self.name = name
         self.mapper = mapper

--- a/env/Lib/site-packages/gslib/vendored/boto/boto/kms/layer1.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/boto/kms/layer1.py
@@ -130,7 +130,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_alias(self, alias_name, target_key_id):
         """
-        Creates a display name for a customer master key. An alias can
+        Creates a display name for a customer main key. An alias can
         be used to identify a key and should be unique. The console
         enforces a one-to-one mapping between the alias and a key. An
         alias name can contain only alphanumeric characters, forward
@@ -174,7 +174,7 @@ class KMSConnection(AWSQueryConnection):
         #. RevokeGrant
 
         :type key_id: string
-        :param key_id: A unique key identifier for a customer master key. This
+        :param key_id: A unique key identifier for a customer main key. This
             value can be a globally unique identifier, an ARN, or an alias.
 
         :type grantee_principal: string
@@ -222,7 +222,7 @@ class KMSConnection(AWSQueryConnection):
 
     def create_key(self, policy=None, description=None, key_usage=None):
         """
-        Creates a customer master key. Customer master keys can be
+        Creates a customer main key. Customer main keys can be
         used to encrypt small amounts of data (less than 4K) directly,
         but they are most commonly used to encrypt or envelope data
         keys that are then used to encrypt customer data. For more
@@ -306,10 +306,10 @@ class KMSConnection(AWSQueryConnection):
     def describe_key(self, key_id):
         """
         Provides detailed information about the specified customer
-        master key.
+        main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             described. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -323,7 +323,7 @@ class KMSConnection(AWSQueryConnection):
         Marks a key as disabled, thereby preventing its use.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             disabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -337,7 +337,7 @@ class KMSConnection(AWSQueryConnection):
         Disables rotation of the specified key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be disabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -352,7 +352,7 @@ class KMSConnection(AWSQueryConnection):
         have up to 25 enabled keys at one time.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key to be
+        :param key_id: Unique identifier of the customer main key to be
             enabled. This can be an ARN, an alias, or a globally unique
             identifier.
 
@@ -363,10 +363,10 @@ class KMSConnection(AWSQueryConnection):
 
     def enable_key_rotation(self, key_id):
         """
-        Enables rotation of the specified customer master key.
+        Enables rotation of the specified customer main key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master key for which
+        :param key_id: Unique identifier of the customer main key for which
             rotation is to be enabled. This can be an ARN, an alias, or a
             globally unique identifier.
 
@@ -378,11 +378,11 @@ class KMSConnection(AWSQueryConnection):
     def encrypt(self, key_id, plaintext, encryption_context=None,
                 grant_tokens=None):
         """
-        Encrypts plaintext into ciphertext by using a customer master
+        Encrypts plaintext into ciphertext by using a customer main
         key.
 
         :type key_id: string
-        :param key_id: Unique identifier of the customer master. This can be an
+        :param key_id: Unique identifier of the customer main. This can be an
             ARN, an alias, or the Key ID.
 
         :type plaintext: blob
@@ -420,7 +420,7 @@ class KMSConnection(AWSQueryConnection):
                           grant_tokens=None):
         """
         Generates a secure data key. Data keys are used to encrypt and
-        decrypt data. They are wrapped by customer master keys.
+        decrypt data. They are wrapped by customer main keys.
 
         :type key_id: string
         :param key_id: Unique identifier of the key. This can be an ARN, an
@@ -472,7 +472,7 @@ class KMSConnection(AWSQueryConnection):
                                             number_of_bytes=None,
                                             grant_tokens=None):
         """
-        Returns a key wrapped by a customer master key without the
+        Returns a key wrapped by a customer main key without the
         plaintext copy of that key. To retrieve the plaintext, see
         GenerateDataKey.
 
@@ -651,7 +651,7 @@ class KMSConnection(AWSQueryConnection):
 
     def list_keys(self, limit=None, marker=None):
         """
-        Lists the customer master keys.
+        Lists the customer main keys.
 
         :type limit: integer
         :param limit: Specify this parameter only when paginating results to
@@ -702,7 +702,7 @@ class KMSConnection(AWSQueryConnection):
                    source_encryption_context=None,
                    destination_encryption_context=None, grant_tokens=None):
         """
-        Encrypts data on the server side with a new customer master
+        Encrypts data on the server side with a new customer main
         key without exposing the plaintext of the data on the client
         side. The data is first decrypted and then encrypted. This
         operation can also be used to change the encryption context of

--- a/env/Lib/site-packages/gslib/vendored/boto/boto/opsworks/layer1.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/boto/opsworks/layer1.py
@@ -2124,7 +2124,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The database's master user name.
+        :param db_user: The database's main user name.
 
         :type db_password: string
         :param db_password: The database password.
@@ -2785,7 +2785,7 @@ class OpsWorksConnection(AWSQueryConnection):
         :param rds_db_instance_arn: The Amazon RDS instance's ARN.
 
         :type db_user: string
-        :param db_user: The master user name.
+        :param db_user: The main user name.
 
         :type db_password: string
         :param db_password: The database password.

--- a/env/Lib/site-packages/gslib/vendored/boto/boto/pyami/bootstrap.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/boto/pyami/bootstrap.py
@@ -88,7 +88,7 @@ class Bootstrap(ScriptBase):
             if update.find(':') >= 0:
                 method, version = update.split(':')
             else:
-                version = 'master'
+                version = 'main'
             self.run('git checkout %s' % version, cwd=location)
         else:
             # first remove the symlink needed when running from subversion

--- a/env/Lib/site-packages/gslib/vendored/boto/boto/rds/__init__.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/boto/rds/__init__.py
@@ -138,8 +138,8 @@ class RDSConnection(AWSQueryConnection):
                           id,
                           allocated_storage,
                           instance_class,
-                          master_username,
-                          master_password,
+                          main_username,
+                          main_password,
                           port=3306,
                           engine='MySQL5.1',
                           db_name=None,
@@ -168,8 +168,8 @@ class RDSConnection(AWSQueryConnection):
         # security_groups should be db_security_groups according to API docs but has been left
         # security_groups for backwards compatibility
         #
-        # master_password should be master_user_password according to API docs but has been left
-        # master_password for backwards compatibility
+        # main_password should be main_user_password according to API docs but has been left
+        # main_password for backwards compatibility
         #
         # instance_class should be db_instance_class according to API docs but has been left
         # instance_class for backwards compatibility
@@ -222,8 +222,8 @@ class RDSConnection(AWSQueryConnection):
                        * sqlserver-web
                        * postgres
 
-        :type master_username: str
-        :param master_username: Name of master user for the DBInstance.
+        :type main_username: str
+        :param main_username: Name of main user for the DBInstance.
 
                                 * MySQL must be;
                                   - 1--16 alphanumeric characters
@@ -240,8 +240,8 @@ class RDSConnection(AWSQueryConnection):
                                   - first character must be a letter
                                   - cannot be a reserver SQL Server word
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
 
                                 * MySQL must be 8--41 alphanumeric characters
 
@@ -398,8 +398,8 @@ class RDSConnection(AWSQueryConnection):
         # engine => Engine
         # engine_version => EngineVersion
         # license_model => LicenseModel
-        # master_username => MasterUsername
-        # master_user_password => MasterUserPassword
+        # main_username => MainUsername
+        # main_user_password => MainUserPassword
         # multi_az => MultiAZ
         # option_group_name => OptionGroupName
         # port => Port
@@ -423,8 +423,8 @@ class RDSConnection(AWSQueryConnection):
                   'EngineVersion': engine_version,
                   'Iops': iops,
                   'LicenseModel': license_model,
-                  'MasterUsername': master_username,
-                  'MasterUserPassword': master_password,
+                  'MainUsername': main_username,
+                  'MainUserPassword': main_password,
                   'MultiAZ': str(multi_az).lower() if multi_az else None,
                   'OptionGroupName': option_group_name,
                   'Port': port,
@@ -562,7 +562,7 @@ class RDSConnection(AWSQueryConnection):
 
     def modify_dbinstance(self, id, param_group=None, security_groups=None,
                           preferred_maintenance_window=None,
-                          master_password=None, allocated_storage=None,
+                          main_password=None, allocated_storage=None,
                           instance_class=None,
                           backup_retention_period=None,
                           preferred_backup_window=None,
@@ -593,8 +593,8 @@ class RDSConnection(AWSQueryConnection):
                                              occur.
                                              Default is Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
                                 Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -680,8 +680,8 @@ class RDSConnection(AWSQueryConnection):
             self.build_list_params(params, l, 'VpcSecurityGroupIds.member')
         if preferred_maintenance_window:
             params['PreferredMaintenanceWindow'] = preferred_maintenance_window
-        if master_password:
-            params['MasterUserPassword'] = master_password
+        if main_password:
+            params['MainUserPassword'] = main_password
         if allocated_storage:
             params['AllocatedStorage'] = allocated_storage
         if instance_class:

--- a/env/Lib/site-packages/gslib/vendored/boto/boto/rds/dbinstance.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/boto/rds/dbinstance.py
@@ -47,7 +47,7 @@ class DBInstance(object):
         in status "available".
     :ivar instance_class: Contains the name of the compute and memory
         capacity class of the DB Instance.
-    :ivar master_username: The username that is set as master username
+    :ivar main_username: The username that is set as main username
         at creation time.
     :ivar parameter_groups: Provides the list of DB Parameter Groups
         applied to this DB Instance.
@@ -98,7 +98,7 @@ class DBInstance(object):
         self.auto_minor_version_upgrade = None
         self.endpoint = None
         self.instance_class = None
-        self.master_username = None
+        self.main_username = None
         self.parameter_groups = []
         self.security_groups = []
         self.read_replica_dbinstance_identifiers = []
@@ -172,8 +172,8 @@ class DBInstance(object):
             self.auto_minor_version_upgrade = value.lower() == 'true'
         elif name == 'DBInstanceClass':
             self.instance_class = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'Port':
             if self._in_endpoint:
                 self._port = int(value)
@@ -293,7 +293,7 @@ class DBInstance(object):
 
     def modify(self, param_group=None, security_groups=None,
                preferred_maintenance_window=None,
-               master_password=None, allocated_storage=None,
+               main_password=None, allocated_storage=None,
                instance_class=None,
                backup_retention_period=None,
                preferred_backup_window=None,
@@ -318,8 +318,8 @@ class DBInstance(object):
             UTC) during which maintenance can occur.  Default is
             Sun:05:00-Sun:09:00
 
-        :type master_password: str
-        :param master_password: Password of master user for the DBInstance.
+        :type main_password: str
+        :param main_password: Password of main user for the DBInstance.
             Must be 4-15 alphanumeric characters.
 
         :type allocated_storage: int
@@ -386,7 +386,7 @@ class DBInstance(object):
                                                  param_group,
                                                  security_groups,
                                                  preferred_maintenance_window,
-                                                 master_password,
+                                                 main_password,
                                                  allocated_storage,
                                                  instance_class,
                                                  backup_retention_period,

--- a/env/Lib/site-packages/gslib/vendored/boto/boto/rds/dbsnapshot.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/boto/rds/dbsnapshot.py
@@ -34,10 +34,10 @@ class DBSnapshot(object):
     :ivar id: Specifies the identifier for the DB Snapshot (DBSnapshotIdentifier)
     :ivar instance_create_time: Specifies the time (UTC) when the snapshot was taken
     :ivar instance_id: Specifies the the DBInstanceIdentifier of the DB Instance this DB Snapshot was created from (DBInstanceIdentifier)
-    :ivar master_username: Provides the master username for the DB Instance
+    :ivar main_username: Provides the main username for the DB Instance
     :ivar port: Specifies the port that the database engine was listening on at the time of the snapshot
     :ivar snapshot_create_time: Provides the time (UTC) when the snapshot was taken
-    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-master-credentials ]
+    :ivar status: Specifies the status of this DB Snapshot. Possible values are [ available, backing-up, creating, deleted, deleting, failed, modifying, rebooting, resetting-main-credentials ]
     :ivar iops: Specifies the Provisioned IOPS (I/O operations per second) value of the DB instance at the time of the snapshot.
     :ivar option_group_name: Provides the option group name for the DB snapshot.
     :ivar percent_progress: The percentage of the estimated data that has been transferred.
@@ -56,7 +56,7 @@ class DBSnapshot(object):
         self.port = None
         self.status = None
         self.availability_zone = None
-        self.master_username = None
+        self.main_username = None
         self.allocated_storage = None
         self.instance_id = None
         self.availability_zone = None
@@ -93,8 +93,8 @@ class DBSnapshot(object):
             self.status = value
         elif name == 'AvailabilityZone':
             self.availability_zone = value
-        elif name == 'MasterUsername':
-            self.master_username = value
+        elif name == 'MainUsername':
+            self.main_username = value
         elif name == 'AllocatedStorage':
             self.allocated_storage = int(value)
         elif name == 'SnapshotTime':

--- a/env/Lib/site-packages/gslib/vendored/boto/boto/rds2/layer1.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/boto/rds2/layer1.py
@@ -321,8 +321,8 @@ class RDSConnection(AWSQueryConnection):
             path='/', params=params)
 
     def create_db_instance(self, db_instance_identifier, allocated_storage,
-                           db_instance_class, engine, master_username,
-                           master_user_password, db_name=None,
+                           db_instance_class, engine, main_username,
+                           main_user_password, db_name=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
                            availability_zone=None, db_subnet_group_name=None,
@@ -417,9 +417,9 @@ class RDSConnection(AWSQueryConnection):
         Valid Values: `MySQL` | `oracle-se1` | `oracle-se` | `oracle-ee` |
             `sqlserver-ee` | `sqlserver-se` | `sqlserver-ex` | `sqlserver-web`
 
-        :type master_username: string
-        :param master_username:
-        The name of master user for the client DB instance.
+        :type main_username: string
+        :param main_username:
+        The name of main user for the client DB instance.
 
         **MySQL**
 
@@ -452,8 +452,8 @@ class RDSConnection(AWSQueryConnection):
         + First character must be a letter.
         + Cannot be a reserved word for the chosen database engine.
 
-        :type master_user_password: string
-        :param master_user_password: The password for the master database user.
+        :type main_user_password: string
+        :param main_user_password: The password for the main database user.
             Can be any printable ASCII character except "/", '"', or "@".
         Type: String
 
@@ -536,7 +536,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas
 
         :type preferred_backup_window: string
@@ -656,8 +656,8 @@ class RDSConnection(AWSQueryConnection):
             'AllocatedStorage': allocated_storage,
             'DBInstanceClass': db_instance_class,
             'Engine': engine,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2488,7 +2488,7 @@ class RDSConnection(AWSQueryConnection):
                            allocated_storage=None, db_instance_class=None,
                            db_security_groups=None,
                            vpc_security_group_ids=None,
-                           apply_immediately=None, master_user_password=None,
+                           apply_immediately=None, main_user_password=None,
                            db_parameter_group_name=None,
                            backup_retention_period=None,
                            preferred_backup_window=None,
@@ -2616,14 +2616,14 @@ class RDSConnection(AWSQueryConnection):
 
         Default: `False`
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the DB instance master user. Can be any printable
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the DB instance main user. Can be any printable
             ASCII character except "/", '"', or "@".
 
         Changing this parameter does not result in an outage and the change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2634,7 +2634,7 @@ class RDSConnection(AWSQueryConnection):
             characters (SQL Server).
 
         Amazon RDS API actions never return the password, so this action
-            provides a way to regain access to a master instance user if the
+            provides a way to regain access to a main instance user if the
             password is lost.
 
         :type db_parameter_group_name: string
@@ -2668,7 +2668,7 @@ class RDSConnection(AWSQueryConnection):
 
 
         + Must be a value from 0 to 8
-        + Cannot be set to 0 if the DB instance is a master instance with read
+        + Cannot be set to 0 if the DB instance is a main instance with read
               replicas or if the DB instance is a read replica
 
         :type preferred_backup_window: string
@@ -2820,8 +2820,8 @@ class RDSConnection(AWSQueryConnection):
         if apply_immediately is not None:
             params['ApplyImmediately'] = str(
                 apply_immediately).lower()
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if db_parameter_group_name is not None:
             params['DBParameterGroupName'] = db_parameter_group_name
         if backup_retention_period is not None:

--- a/env/Lib/site-packages/gslib/vendored/boto/boto/redshift/layer1.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/boto/redshift/layer1.py
@@ -310,8 +310,8 @@ class RedshiftConnection(AWSQueryConnection):
             verb='POST',
             path='/', params=params)
 
-    def create_cluster(self, cluster_identifier, node_type, master_username,
-                       master_user_password, db_name=None, cluster_type=None,
+    def create_cluster(self, cluster_identifier, node_type, main_username,
+                       main_user_password, db_name=None, cluster_type=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
                        cluster_subnet_group_name=None,
@@ -391,9 +391,9 @@ class RedshiftConnection(AWSQueryConnection):
         Valid Values: `dw1.xlarge` | `dw1.8xlarge` | `dw2.large` |
             `dw2.8xlarge`.
 
-        :type master_username: string
-        :param master_username:
-        The user name associated with the master user account for the cluster
+        :type main_username: string
+        :param main_username:
+        The user name associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -404,9 +404,9 @@ class RedshiftConnection(AWSQueryConnection):
         + Cannot be a reserved word. A list of reserved words can be found in
               `Reserved Words`_ in the Amazon Redshift Database Developer Guide.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The password associated with the master user account for the cluster
+        :type main_user_password: string
+        :param main_user_password:
+        The password associated with the main user account for the cluster
             that is being created.
 
         Constraints:
@@ -573,8 +573,8 @@ class RedshiftConnection(AWSQueryConnection):
         params = {
             'ClusterIdentifier': cluster_identifier,
             'NodeType': node_type,
-            'MasterUsername': master_username,
-            'MasterUserPassword': master_user_password,
+            'MainUsername': main_username,
+            'MainUserPassword': main_user_password,
         }
         if db_name is not None:
             params['DBName'] = db_name
@@ -2253,7 +2253,7 @@ class RedshiftConnection(AWSQueryConnection):
                        node_type=None, number_of_nodes=None,
                        cluster_security_groups=None,
                        vpc_security_group_ids=None,
-                       master_user_password=None,
+                       main_user_password=None,
                        cluster_parameter_group_name=None,
                        automated_snapshot_retention_period=None,
                        preferred_maintenance_window=None,
@@ -2264,7 +2264,7 @@ class RedshiftConnection(AWSQueryConnection):
         """
         Modifies the settings for a cluster. For example, you can add
         another security or parameter group, update the preferred
-        maintenance window, or change the master user password.
+        maintenance window, or change the main user password.
         Resetting a cluster password or modifying the security groups
         associated with a cluster do not need a reboot. However,
         modifying a parameter group requires a reboot for parameters
@@ -2345,11 +2345,11 @@ class RedshiftConnection(AWSQueryConnection):
         :param vpc_security_group_ids: A list of virtual private cloud (VPC)
             security groups to be associated with the cluster.
 
-        :type master_user_password: string
-        :param master_user_password:
-        The new password for the cluster master user. This change is
+        :type main_user_password: string
+        :param main_user_password:
+        The new password for the cluster main user. This change is
             asynchronously applied as soon as possible. Between the time of the
-            request and the completion of the request, the `MasterUserPassword`
+            request and the completion of the request, the `MainUserPassword`
             element exists in the `PendingModifiedValues` element of the
             operation response.
 
@@ -2464,8 +2464,8 @@ class RedshiftConnection(AWSQueryConnection):
             self.build_list_params(params,
                                    vpc_security_group_ids,
                                    'VpcSecurityGroupIds.member')
-        if master_user_password is not None:
-            params['MasterUserPassword'] = master_user_password
+        if main_user_password is not None:
+            params['MainUserPassword'] = main_user_password
         if cluster_parameter_group_name is not None:
             params['ClusterParameterGroupName'] = cluster_parameter_group_name
         if automated_snapshot_retention_period is not None:

--- a/env/Lib/site-packages/gslib/vendored/boto/tests/integration/rds2/test_connection.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/tests/integration/rds2/test_connection.py
@@ -44,8 +44,8 @@ class TestRDS2Connection(unittest.TestCase):
             allocated_storage=5,
             db_instance_class='db.t1.micro',
             engine='postgres',
-            master_username='bototestuser',
-            master_user_password='testtestt3st',
+            main_username='bototestuser',
+            main_user_password='testtestt3st',
             # Try to limit the impact & test options.
             multi_az=False,
             backup_retention_period=0

--- a/env/Lib/site-packages/gslib/vendored/boto/tests/integration/redshift/test_layer1.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/tests/integration/redshift/test_layer1.py
@@ -36,8 +36,8 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         self.api = RedshiftConnection()
         self.cluster_prefix = 'boto-redshift-cluster-%s'
         self.node_type = 'dw.hs1.xlarge'
-        self.master_username = 'mrtest'
-        self.master_password = 'P4ssword'
+        self.main_username = 'mrtest'
+        self.main_password = 'P4ssword'
         self.db_name = 'simon'
         # Redshift was taking ~20 minutes to bring clusters up in testing.
         self.wait_time = 60 * 20
@@ -50,7 +50,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 
@@ -71,7 +71,7 @@ class TestRedshiftLayer1Management(unittest.TestCase):
         cluster_id = self.cluster_id()
         self.api.create_cluster(
             cluster_id, self.node_type,
-            self.master_username, self.master_password,
+            self.main_username, self.main_password,
             db_name=self.db_name, number_of_nodes=3
         )
 

--- a/env/Lib/site-packages/gslib/vendored/boto/tests/unit/emr/test_connection.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/tests/unit/emr/test_connection.py
@@ -193,7 +193,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
             <EndDateTime>2014-01-24T02:19:46Z</EndDateTime>
           </Timeline>
         </Status>
-        <Name>Master instance group</Name>
+        <Name>Main instance group</Name>
         <RequestedInstanceCount>1</RequestedInstanceCount>
         <RunningInstanceCount>0</RunningInstanceCount>
         <InstanceGroupType>MASTER</InstanceGroupType>
@@ -253,7 +253,7 @@ class TestListInstanceGroups(AWSMockServiceTestCase):
         self.assertEqual(response.instancegroups[0].instancetype, "m1.large")
         self.assertEqual(response.instancegroups[0].market, "ON_DEMAND")
         self.assertEqual(
-            response.instancegroups[0].name, "Master instance group")
+            response.instancegroups[0].name, "Main instance group")
         self.assertEqual(
             response.instancegroups[0].requestedinstancecount, '1')
         self.assertEqual(response.instancegroups[0].runninginstancecount, '0')
@@ -587,7 +587,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         </member>
       </Applications>
       <TerminationProtected>false</TerminationProtected>
-      <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+      <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
       <NormalizedInstanceHours>10</NormalizedInstanceHours>
       <ServiceRole>my-service-role</ServiceRole>
     </Cluster>
@@ -622,7 +622,7 @@ class TestDescribeCluster(AWSMockServiceTestCase):
         self.assertEqual(response.applications[0].name, 'hadoop')
         self.assertEqual(response.applications[0].version, '1.0.3')
         self.assertEqual(
-            response.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+            response.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(response.normalizedinstancehours, '10')
         self.assertEqual(response.servicerole, 'my-service-role')
 
@@ -862,7 +862,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
           <Placement>
             <AvailabilityZone>us-west-1c</AvailabilityZone>
           </Placement>
-          <MasterInstanceType>m1.large</MasterInstanceType>
+          <MainInstanceType>m1.large</MainInstanceType>
           <Ec2KeyName>my_key</Ec2KeyName>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
           <InstanceGroups>
@@ -879,7 +879,7 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Market>ON_DEMAND</Market>
               <InstanceGroupId>ig-aaaaaa</InstanceGroupId>
               <InstanceRole>MASTER</InstanceRole>
-              <Name>Master instance group</Name>
+              <Name>Main instance group</Name>
             </member>
             <member>
               <CreationDateTime>2014-01-24T01:21:21Z</CreationDateTime>
@@ -897,11 +897,11 @@ class DescribeJobFlowsTestBase(AWSMockServiceTestCase):
               <Name>Core instance group</Name>
             </member>
           </InstanceGroups>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-aaaaaa</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-aaaaaa</MainInstanceId>
           <HadoopVersion>1.0.3</HadoopVersion>
           <NormalizedInstanceHours>12</NormalizedInstanceHours>
-          <MasterPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MasterPublicDnsName>
+          <MainPublicDnsName>ec2-184-0-0-1.us-west-1.compute.amazonaws.com</MainPublicDnsName>
           <InstanceCount>3</InstanceCount>
           <TerminationProtected>false</TerminationProtected>
         </Instances>
@@ -930,15 +930,15 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(jf.name, 'test analytics')
         self.assertEqual(jf.jobflowid, 'j-aaaaaa')
         self.assertEqual(jf.ec2keyname, 'my_key')
-        self.assertEqual(jf.masterinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstancetype, 'm1.large')
         self.assertEqual(jf.availabilityzone, 'us-west-1c')
         self.assertEqual(jf.keepjobflowalivewhennosteps, 'true')
-        self.assertEqual(jf.slaveinstancetype, 'm1.large')
-        self.assertEqual(jf.masterinstanceid, 'i-aaaaaa')
+        self.assertEqual(jf.subordinateinstancetype, 'm1.large')
+        self.assertEqual(jf.maininstanceid, 'i-aaaaaa')
         self.assertEqual(jf.hadoopversion, '1.0.3')
         self.assertEqual(jf.normalizedinstancehours, '12')
         self.assertEqual(
-            jf.masterpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
+            jf.mainpublicdnsname, 'ec2-184-0-0-1.us-west-1.compute.amazonaws.com')
         self.assertEqual(jf.instancecount, '3')
         self.assertEqual(jf.terminationprotected, 'false')
 
@@ -961,7 +961,7 @@ class TestDescribeJobFlows(DescribeJobFlowsTestBase):
         self.assertEqual(ig.market, 'ON_DEMAND')
         self.assertEqual(ig.instancegroupid, 'ig-aaaaaa')
         self.assertEqual(ig.instancerole, 'MASTER')
-        self.assertEqual(ig.name, 'Master instance group')
+        self.assertEqual(ig.name, 'Main instance group')
 
     def test_describe_jobflows_no_args(self):
         self.set_http_response(200)
@@ -1033,8 +1033,8 @@ class TestRunJobFlow(AWSMockServiceTestCase):
             'Name': 'EmrCluster'},
             ignore_params_values=['ActionOnFailure', 'Instances.InstanceCount',
                                   'Instances.KeepJobFlowAliveWhenNoSteps',
-                                  'Instances.MasterInstanceType',
-                                  'Instances.SlaveInstanceType'])
+                                  'Instances.MainInstanceType',
+                                  'Instances.SubordinateInstanceType'])
 
     def test_run_jobflow_enable_debugging(self):
         self.region = 'ap-northeast-2'

--- a/env/Lib/site-packages/gslib/vendored/boto/tests/unit/emr/test_emr_responses.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/tests/unit/emr/test_emr_responses.py
@@ -85,8 +85,8 @@ JOB_FLOW_EXAMPLE = b"""
           <Placement>
             <AvailabilityZone>us-east-1a</AvailabilityZone>
           </Placement>
-          <SlaveInstanceType>m1.small</SlaveInstanceType>
-          <MasterInstanceType>m1.small</MasterInstanceType>
+          <SubordinateInstanceType>m1.small</SubordinateInstanceType>
+          <MainInstanceType>m1.small</MainInstanceType>
           <Ec2KeyName>myec2keyname</Ec2KeyName>
           <InstanceCount>4</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>true</KeepJobFlowAliveWhenNoSteps>
@@ -281,8 +281,8 @@ JOB_FLOW_COMPLETED = b"""
         </Steps>
         <JobFlowId>j-3H3Q13JPFLU22</JobFlowId>
         <Instances>
-          <SlaveInstanceType>m1.large</SlaveInstanceType>
-          <MasterInstanceId>i-64c21609</MasterInstanceId>
+          <SubordinateInstanceType>m1.large</SubordinateInstanceType>
+          <MainInstanceId>i-64c21609</MainInstanceId>
           <Placement>
             <AvailabilityZone>us-east-1b</AvailabilityZone>
           </Placement>
@@ -300,7 +300,7 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>MASTER</InstanceRole>
               <InstanceGroupId>ig-EVMHOZJ2SCO8</InstanceGroupId>
-              <Name>master</Name>
+              <Name>main</Name>
             </member>
             <member>
               <CreationDateTime>2010-10-21T01:00:25Z</CreationDateTime>
@@ -315,13 +315,13 @@ JOB_FLOW_COMPLETED = b"""
               <LastStateChangeReason>Job flow terminated</LastStateChangeReason>
               <InstanceRole>CORE</InstanceRole>
               <InstanceGroupId>ig-YZHDYVITVHKB</InstanceGroupId>
-              <Name>slave</Name>
+              <Name>subordinate</Name>
             </member>
           </InstanceGroups>
           <NormalizedInstanceHours>40</NormalizedInstanceHours>
           <HadoopVersion>0.20</HadoopVersion>
-          <MasterInstanceType>m1.large</MasterInstanceType>
-          <MasterPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MasterPublicDnsName>
+          <MainInstanceType>m1.large</MainInstanceType>
+          <MainPublicDnsName>ec2-184-72-153-139.compute-1.amazonaws.com</MainPublicDnsName>
           <Ec2KeyName>myubersecurekey</Ec2KeyName>
           <InstanceCount>10</InstanceCount>
           <KeepJobFlowAliveWhenNoSteps>false</KeepJobFlowAliveWhenNoSteps>
@@ -361,8 +361,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='mybucket/subdir/',
                             name='MyJobFlowName',
                             availabilityzone='us-east-1a',
-                            slaveinstancetype='m1.small',
-                            masterinstancetype='m1.small',
+                            subordinateinstancetype='m1.small',
+                            maininstancetype='m1.small',
                             ec2keyname='myec2keyname',
                             keepjobflowalivewhennosteps='true')
 
@@ -379,8 +379,8 @@ class TestEMRResponses(unittest.TestCase):
                             loguri='s3n://example.emrtest.scripts/jobflow_logs/',
                             name='RealJobFlowName',
                             availabilityzone='us-east-1b',
-                            slaveinstancetype='m1.large',
-                            masterinstancetype='m1.large',
+                            subordinateinstancetype='m1.large',
+                            maininstancetype='m1.large',
                             ec2keyname='myubersecurekey',
                             keepjobflowalivewhennosteps='false')
         self.assertEquals(6, len(jobflow.steps))

--- a/env/Lib/site-packages/gslib/vendored/boto/tests/unit/emr/test_instance_group_args.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/tests/unit/emr/test_instance_group_args.py
@@ -19,7 +19,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         """
         with self.assertRaisesRegexp(ValueError, 'bidprice must be specified'):
             InstanceGroup(1, 'MASTER', 'm1.small',
-                          'SPOT', 'master')
+                          'SPOT', 'main')
 
     def test_bidprice_missing_ondemand(self):
         """
@@ -27,14 +27,14 @@ class TestInstanceGroupArgs(unittest.TestCase):
         ON_DEMAND.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'ON_DEMAND', 'master')
+                                       'ON_DEMAND', 'main')
 
     def test_bidprice_Decimal(self):
         """
         Test InstanceGroup init works with bidprice type = Decimal.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=Decimal(1.10))
+                                       'SPOT', 'main', bidprice=Decimal(1.10))
         self.assertEquals('1.10', instance_group.bidprice[:4])
 
     def test_bidprice_float(self):
@@ -42,7 +42,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = float.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice=1.1)
+                                       'SPOT', 'main', bidprice=1.1)
         self.assertEquals('1.1', instance_group.bidprice)
 
     def test_bidprice_string(self):
@@ -50,7 +50,7 @@ class TestInstanceGroupArgs(unittest.TestCase):
         Test InstanceGroup init works with bidprice type = string.
         """
         instance_group = InstanceGroup(1, 'MASTER', 'm1.small',
-                                       'SPOT', 'master', bidprice='1.1')
+                                       'SPOT', 'main', bidprice='1.1')
         self.assertEquals('1.1', instance_group.bidprice)
 
 if __name__ == "__main__":

--- a/env/Lib/site-packages/gslib/vendored/boto/tests/unit/rds/test_connection.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/tests/unit/rds/test_connection.py
@@ -88,7 +88,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
                   <InstanceCreateTime>2012-10-03T22:01:51.047Z</InstanceCreateTime>
                   <AllocatedStorage>200</AllocatedStorage>
                   <DBInstanceClass>db.m1.large</DBInstanceClass>
-                  <MasterUsername>awsuser</MasterUsername>
+                  <MainUsername>awsuser</MainUsername>
                   <StatusInfos>
                     <DBInstanceStatusInfo>
                       <Message></Message>
@@ -150,7 +150,7 @@ class TestRDSConnection(AWSMockServiceTestCase):
             db.endpoint,
             (u'mydbinstance2.c0hjqouvn9mf.us-west-2.rds.amazonaws.com', 3306))
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'awsuser')
+        self.assertEqual(db.main_username, 'awsuser')
         self.assertEqual(db.availability_zone, 'us-west-2b')
         self.assertEqual(db.backup_retention_period, 1)
         self.assertEqual(db.preferred_backup_window, '10:30-11:00')
@@ -198,7 +198,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <ReadReplicaDBInstanceIdentifiers/>
                     <Engine>mysql</Engine>
                     <PendingModifiedValues>
-                        <MasterUserPassword>****</MasterUserPassword>
+                        <MainUserPassword>****</MainUserPassword>
                     </PendingModifiedValues>
                     <BackupRetentionPeriod>0</BackupRetentionPeriod>
                     <MultiAZ>false</MultiAZ>
@@ -252,7 +252,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
                     <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                         <AllocatedStorage>10</AllocatedStorage>
                         <DBInstanceClass>db.m1.large</DBInstanceClass>
-                        <MasterUsername>master</MasterUsername>
+                        <MainUsername>main</MainUsername>
                 </DBInstance>
             </CreateDBInstanceResult>
             <ResponseMetadata>
@@ -267,7 +267,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -283,8 +283,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306
         }, ignore_params_values=['Version'])
 
@@ -293,10 +293,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
 
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
@@ -312,7 +312,7 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group=param_group,
             db_subnet_group_name='dbSubnetgroup01')
@@ -326,8 +326,8 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
         }, ignore_params_values=['Version'])
 
@@ -336,10 +336,10 @@ class TestRDSCCreateDBInstance(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
         self.assertEqual(db.pending_modified_values,
-            {'MasterUserPassword': '****'})
+            {'MainUserPassword': '****'})
         self.assertEqual(db.parameter_group.name,
                          'default.mysql5.1')
         self.assertEqual(db.parameter_group.description, None)
@@ -383,7 +383,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
               <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
               <AllocatedStorage>10</AllocatedStorage>
               <DBInstanceClass>db.m1.large</DBInstanceClass>
-              <MasterUsername>master</MasterUsername>
+              <MainUsername>main</MainUsername>
             </DBInstance>
           </RestoreDBInstanceToPointInTimeResult>
           <ResponseMetadata>
@@ -411,7 +411,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
         self.assertEqual(db.status, 'creating')
         self.assertEqual(db.allocated_storage, 10)
         self.assertEqual(db.instance_class, 'db.m1.large')
-        self.assertEqual(db.master_username, 'master')
+        self.assertEqual(db.main_username, 'main')
         self.assertEqual(db.multi_az, False)
 
         self.assertEqual(db.parameter_group.name,
@@ -445,7 +445,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -460,8 +460,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -481,7 +481,7 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'SimCoProd01',
             10,
             'db.m1.large',
-            'master',
+            'main',
             'Password01',
             param_group='default.mysql5.1',
             db_subnet_group_name='dbSubnetgroup01',
@@ -496,8 +496,8 @@ class TestRDSConnectionRestoreDBInstanceFromPointInTime(AWSMockServiceTestCase):
             'DBParameterGroupName': 'default.mysql5.1',
             'DBSubnetGroupName': 'dbSubnetgroup01',
             'Engine': 'MySQL5.1',
-            'MasterUsername': 'master',
-            'MasterUserPassword': 'Password01',
+            'MainUsername': 'main',
+            'MainUserPassword': 'Password01',
             'Port': 3306,
             'VpcSecurityGroupIds.member.1': 'sg-1',
             'VpcSecurityGroupIds.member.2': 'sg-2'
@@ -674,9 +674,9 @@ class TestRDSLogFileDownload(AWSMockServiceTestCase):
 
 2014-01-27 09:35:15.44 spid74      I/O is frozen on database rdsadmin. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:15.44 spid73      I/O is frozen on database master. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
+2014-01-27 09:35:15.44 spid73      I/O is frozen on database main. No user action is required. However, if I/O is not resumed promptly, you could cancel the backup.
 
-2014-01-27 09:35:25.57 spid73      I/O was resumed on database master. No user action is required.
+2014-01-27 09:35:25.57 spid73      I/O was resumed on database main. No user action is required.
 
 2014-01-27 09:35:25.57 spid74      I/O was resumed on database rdsadmin. No user action is required.
 

--- a/env/Lib/site-packages/gslib/vendored/boto/tests/unit/rds/test_snapshot.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/tests/unit/rds/test_snapshot.py
@@ -27,7 +27,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.50</EngineVersion>
                     <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                     <PercentProgress>100</PercentProgress>
@@ -47,7 +47,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.49</EngineVersion>
                     <DBSnapshotIdentifier>mysnapshot1</DBSnapshotIdentifier>
                     <SnapshotType>manual</SnapshotType>
-                    <MasterUsername>sa</MasterUsername>
+                    <MainUsername>sa</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -64,7 +64,7 @@ class TestDescribeDBSnapshots(AWSMockServiceTestCase):
                     <EngineVersion>5.1.47</EngineVersion>
                     <DBSnapshotIdentifier>rds:simcoprod01-2012-04-02-00-01</DBSnapshotIdentifier>
                     <SnapshotType>automated</SnapshotType>
-                    <MasterUsername>master</MasterUsername>
+                    <MainUsername>main</MainUsername>
                     <OptionGroupName>myoptiongroupname</OptionGroupName>
                     <Iops>1000</Iops>
                 </DBSnapshot>
@@ -118,7 +118,7 @@ class TestCreateDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mydbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CreateDBSnapshotResult>
             <ResponseMetadata>
@@ -160,7 +160,7 @@ class TestCopyDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.50</EngineVersion>
                 <DBSnapshotIdentifier>mycopieddbsnapshot</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </CopyDBSnapshotResult>
             <ResponseMetadata>
@@ -202,7 +202,7 @@ class TestDeleteDBSnapshot(AWSMockServiceTestCase):
                 <EngineVersion>5.1.47</EngineVersion>
                 <DBSnapshotIdentifier>mysnapshot2</DBSnapshotIdentifier>
                 <SnapshotType>manual</SnapshotType>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBSnapshot>
             </DeleteDBSnapshotResult>
             <ResponseMetadata>
@@ -257,7 +257,7 @@ class TestRestoreDBInstanceFromDBSnapshot(AWSMockServiceTestCase):
                 <PreferredMaintenanceWindow>sat:07:30-sat:08:00</PreferredMaintenanceWindow>
                 <AllocatedStorage>10</AllocatedStorage>
                 <DBInstanceClass>db.m1.large</DBInstanceClass>
-                <MasterUsername>master</MasterUsername>
+                <MainUsername>main</MainUsername>
                 </DBInstance>
             </RestoreDBInstanceFromDBSnapshotResult>
             <ResponseMetadata>

--- a/env/Lib/site-packages/gslib/vendored/boto/tests/unit/route53/test_connection.py
+++ b/env/Lib/site-packages/gslib/vendored/boto/tests/unit/route53/test_connection.py
@@ -509,7 +509,7 @@ class TestTruncatedGetAllRRSetsRoute53(AWSMockServiceTestCase):
       <TTL>1800</TTL>
       <ResourceRecords>
         <ResourceRecord>
-          <Value>ns-1929.awsdns-93.net. hostmaster.awsdns.net. 1 10800 3600 604800 1800</Value>
+          <Value>ns-1929.awsdns-93.net. hostmain.awsdns.net. 1 10800 3600 604800 1800</Value>
         </ResourceRecord>
       </ResourceRecords>
     </ResourceRecordSet>

--- a/env/Lib/site-packages/nltk/corpus/reader/timit.py
+++ b/env/Lib/site-packages/nltk/corpus/reader/timit.py
@@ -85,7 +85,7 @@ The timit corpus reader provides 4 functions and 4 data items.
      race       speaker race (WHT:white, BLK:black, AMR:american indian,
                 SPN:spanish-american, ORN:oriental,???:unknown)
      edu        speaker education level (HS:high school, AS:associate degree,
-                BS:bachelor's degree (BS or BA), MS:master's degree (MS or MA),
+                BS:bachelor's degree (BS or BA), MS:main's degree (MS or MA),
                 PHD:doctorate degree (PhD,JD,MD), ??:unknown)
      comments   comments by the recorder
 

--- a/env/Lib/site-packages/nltk/draw/table.py
+++ b/env/Lib/site-packages/nltk/draw/table.py
@@ -64,11 +64,11 @@ class MultiListbox(Frame):
     # Constructor
     # /////////////////////////////////////////////////////////////////
 
-    def __init__(self, master, columns, column_weights=None, cnf={}, **kw):
+    def __init__(self, main, columns, column_weights=None, cnf={}, **kw):
         """
         Construct a new multi-column listbox widget.
 
-        :param master: The widget that should contain the new
+        :param main: The widget that should contain the new
             multi-column listbox.
 
         :param columns: Specifies what columns should be included in
@@ -82,7 +82,7 @@ class MultiListbox(Frame):
             Use ``label_*`` to configure all labels; and ``listbox_*``
             to configure all listboxes.  E.g.:
 
-                >>> mlb = MultiListbox(master, 5, label_foreground='red')
+                >>> mlb = MultiListbox(main, 5, label_foreground='red')
         """
         # If columns was specified as an int, convert it to a list.
         if isinstance(columns, int):
@@ -107,7 +107,7 @@ class MultiListbox(Frame):
         self._column_weights = column_weights
 
         # Configure our widgets.
-        Frame.__init__(self, master, **self.FRAME_CONFIG)
+        Frame.__init__(self, main, **self.FRAME_CONFIG)
         self.grid_rowconfigure(1, weight=1)
         for i, label in enumerate(self._column_names):
             self.grid_columnconfigure(i, weight=column_weights[i])
@@ -305,7 +305,7 @@ class MultiListbox(Frame):
         Configure this widget.  Use ``label_*`` to configure all
         labels; and ``listbox_*`` to configure all listboxes.  E.g.:
 
-                >>> mlb = MultiListbox(master, 5)
+                >>> mlb = MultiListbox(main, 5)
                 >>> mlb.configure(label_foreground='red')
                 >>> mlb.configure(listbox_foreground='red')
         """
@@ -623,7 +623,7 @@ class Table(object):
 
     def __init__(
         self,
-        master,
+        main,
         column_names,
         rows=None,
         column_weights=None,
@@ -636,8 +636,8 @@ class Table(object):
         """
         Construct a new Table widget.
 
-        :type master: Tkinter.Widget
-        :param master: The widget that should contain the new table.
+        :type main: Tkinter.Widget
+        :param main: The widget that should contain the new table.
         :type column_names: list(str)
         :param column_names: A list of names for the columns; these
             names will be used to create labels for each column;
@@ -666,7 +666,7 @@ class Table(object):
         """
         self._num_columns = len(column_names)
         self._reprfunc = reprfunc
-        self._frame = Frame(master)
+        self._frame = Frame(main)
 
         self._column_name_to_index = dict((c, i) for (i, c) in enumerate(column_names))
 

--- a/env/Lib/site-packages/nltk/draw/util.py
+++ b/env/Lib/site-packages/nltk/draw/util.py
@@ -2451,7 +2451,7 @@ class ColorizedList(object):
 
 
 class MutableOptionMenu(Menubutton):
-    def __init__(self, master, values, **options):
+    def __init__(self, main, values, **options):
         self._callback = options.get('command')
         if 'command' in options:
             del options['command']
@@ -2470,7 +2470,7 @@ class MutableOptionMenu(Menubutton):
             "highlightthickness": 2,
         }
         kw.update(options)
-        Widget.__init__(self, master, "menubutton", kw)
+        Widget.__init__(self, main, "menubutton", kw)
         self.widgetName = 'tk_optionMenu'
         self._menu = Menu(self, name="menu", tearoff=0)
         self.menuname = self._menu._w

--- a/env/Lib/site-packages/nltk/featstruct.py
+++ b/env/Lib/site-packages/nltk/featstruct.py
@@ -2678,7 +2678,7 @@ def interactive_demo(trace=False):
         print()
 
     while True:
-        # Pick 5 feature structures at random from the master list.
+        # Pick 5 feature structures at random from the main list.
         MAX_CHOICES = 5
         if len(all_fstructs) > MAX_CHOICES:
             fstructs = sorted(random.sample(all_fstructs, MAX_CHOICES))

--- a/env/Lib/site-packages/nltk/misc/chomsky.py
+++ b/env/Lib/site-packages/nltk/misc/chomsky.py
@@ -3,7 +3,7 @@
 
 """
 CHOMSKY is an aid to writing linguistic papers in the style
-of the great master.  It is based on selected phrases taken
+of the great main.  It is based on selected phrases taken
 from actual books and articles written by Noam Chomsky.
 Upon request, it assembles the phrases in the elegant
 stylistic patterns that Chomsky is noted for.

--- a/env/Lib/site-packages/nltk/sem/drt.py
+++ b/env/Lib/site-packages/nltk/sem/drt.py
@@ -1104,31 +1104,31 @@ class DrsDrawer(object):
         :param size_canvas: bool, True if the canvas size should be the exact size of the DRS
         :param canvas: ``Canvas`` The canvas on which to draw the DRS.  If none is given, create a new canvas.
         """
-        master = None
+        main = None
         if not canvas:
-            master = Tk()
-            master.title("DRT")
+            main = Tk()
+            main.title("DRT")
 
             font = Font(family='helvetica', size=12)
 
             if size_canvas:
-                canvas = Canvas(master, width=0, height=0)
+                canvas = Canvas(main, width=0, height=0)
                 canvas.font = font
                 self.canvas = canvas
                 (right, bottom) = self._visit(drs, self.OUTERSPACE, self.TOPSPACE)
 
                 width = max(right + self.OUTERSPACE, 100)
                 height = bottom + self.OUTERSPACE
-                canvas = Canvas(master, width=width, height=height)  # , bg='white')
+                canvas = Canvas(main, width=width, height=height)  # , bg='white')
             else:
-                canvas = Canvas(master, width=300, height=300)
+                canvas = Canvas(main, width=300, height=300)
 
             canvas.pack()
             canvas.font = font
 
         self.canvas = canvas
         self.drs = drs
-        self.master = master
+        self.main = main
 
     def _get_text_height(self):
         """Get the height of a line of text"""
@@ -1138,8 +1138,8 @@ class DrsDrawer(object):
         """Draw the DRS"""
         self._handle(self.drs, self._draw_command, x, y)
 
-        if self.master and not in_idle():
-            self.master.mainloop()
+        if self.main and not in_idle():
+            self.main.mainloop()
         else:
             return self._visit(self.drs, x, y)
 

--- a/env/Lib/site-packages/nltk/sem/logic.py
+++ b/env/Lib/site-packages/nltk/sem/logic.py
@@ -917,10 +917,10 @@ def typecheck(expressions, signature=None):
     :param signature: dict that maps variable names to types (or string
     representations of types)
     """
-    # typecheck and create master signature
+    # typecheck and create main signature
     for expression in expressions:
         signature = expression.typecheck(signature)
-    # apply master signature to all expressions
+    # apply main signature to all expressions
     for expression in expressions[:-1]:
         expression.typecheck(signature)
     return signature

--- a/env/Lib/site-packages/pbr/builddoc.py
+++ b/env/Lib/site-packages/pbr/builddoc.py
@@ -178,7 +178,7 @@ class LocalBuildDoc(setup_command.BuildDoc):
                 raise
 
         if self.link_index:
-            src = app.config.master_doc + app.builder.out_suffix
+            src = app.config.main_doc + app.builder.out_suffix
             dst = app.builder.get_outfilename('index')
             os.symlink(src, dst)
 

--- a/env/Lib/site-packages/pbr/git.py
+++ b/env/Lib/site-packages/pbr/git.py
@@ -242,8 +242,8 @@ def _iter_log_inner(git_dir):
 
         # refname can be:
         #  <empty>
-        #  HEAD, tag: refs/tags/1.4.0, refs/remotes/origin/master, \
-        #    refs/heads/master
+        #  HEAD, tag: refs/tags/1.4.0, refs/remotes/origin/main, \
+        #    refs/heads/main
         #  refs/tags/1.3.4
         if "refs/tags/" in refname:
             refname = refname.strip()[1:-1]  # remove wrapping ()'s

--- a/env/Lib/site-packages/pbr/tests/test_setup.py
+++ b/env/Lib/site-packages/pbr/tests/test_setup.py
@@ -112,7 +112,7 @@ d7e6167\x00Bug fix: Fix pass thru filtering in list_networks\x00 (tag: refs/tags
 c47ec15\x00Consider 'in-use' a non-pending volume for caching\x00 (tag: refs/tags/ev)il)
 8696fbd\x00Improve test coverage: private extension API\x00 (tag: refs/tags/ev(il)
 f0440f8\x00Improve test coverage: hypervisor list\x00 (tag: refs/tags/e(vi)l)
-04984a5\x00Refactor hooks file.\x00 (HEAD, tag: 0.6.7,b, tag: refs/tags/(12), refs/heads/master)
+04984a5\x00Refactor hooks file.\x00 (HEAD, tag: 0.6.7,b, tag: refs/tags/(12), refs/heads/main)
 a65e8ee\x00Remove jinja pin.\x00 (tag: refs/tags/0.5.14, tag: refs/tags/0.5.13)
 """  # noqa
 

--- a/env/Lib/site-packages/pbr/tests/testpackage/doc/source/conf.py
+++ b/env/Lib/site-packages/pbr/tests/testpackage/doc/source/conf.py
@@ -28,8 +28,8 @@ extensions = [
 # The suffix of source filenames.
 source_suffix = '.rst'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'testpackage'

--- a/env/Lib/site-packages/pip/_internal/vcs/git.py
+++ b/env/Lib/site-packages/pip/_internal/vcs/git.py
@@ -226,7 +226,7 @@ class Git(VersionControl):
             self.run_command(['fetch', '-q', '--tags'], cwd=dest)
         else:
             self.run_command(['fetch', '-q'], cwd=dest)
-        # Then reset to wanted revision (maybe even origin/master)
+        # Then reset to wanted revision (maybe even origin/main)
         rev_options = self.resolve_revision(dest, url, rev_options)
         cmd_args = ['reset', '--hard', '-q'] + rev_options.to_args()
         self.run_command(cmd_args, cwd=dest)

--- a/env/Lib/site-packages/pip/_vendor/pkg_resources/__init__.py
+++ b/env/Lib/site-packages/pip/_vendor/pkg_resources/__init__.py
@@ -567,9 +567,9 @@ class WorkingSet:
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3239,9 +3239,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3251,7 +3251,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/env/Lib/site-packages/pkg_resources/__init__.py
+++ b/env/Lib/site-packages/pkg_resources/__init__.py
@@ -567,9 +567,9 @@ class WorkingSet:
             self.add_entry(entry)
 
     @classmethod
-    def _build_master(cls):
+    def _build_main(cls):
         """
-        Prepare the master working set.
+        Prepare the main working set.
         """
         ws = cls()
         try:
@@ -3248,9 +3248,9 @@ def _initialize(g=globals()):
 
 
 @_call_aside
-def _initialize_master_working_set():
+def _initialize_main_working_set():
     """
-    Prepare the master working set and make the ``require()``
+    Prepare the main working set and make the ``require()``
     API available.
 
     This function has explicit effects on the global state
@@ -3260,7 +3260,7 @@ def _initialize_master_working_set():
     Invocation by other packages is unsupported and done
     at their own risk.
     """
-    working_set = WorkingSet._build_master()
+    working_set = WorkingSet._build_main()
     _declare_state('object', working_set=working_set)
 
     require = working_set.require

--- a/env/Lib/site-packages/plotly/graph_objs/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/__init__.py
@@ -349,11 +349,11 @@ class Waterfall(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -1180,11 +1180,11 @@ class Waterfall(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available. variables `initial`, `delta`, `final` and `label`.
@@ -1609,12 +1609,12 @@ class Waterfall(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -1755,12 +1755,12 @@ class Waterfall(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `initial`,
@@ -1960,12 +1960,12 @@ class Waterfall(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -2106,12 +2106,12 @@ class Waterfall(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `initial`,
@@ -2726,10 +2726,10 @@ class Volume(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -3095,11 +3095,11 @@ class Volume(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -4071,12 +4071,12 @@ class Volume(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -4376,12 +4376,12 @@ class Volume(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -5070,11 +5070,11 @@ class Violin(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -6185,12 +6185,12 @@ class Violin(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -6517,12 +6517,12 @@ class Violin(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -7199,11 +7199,11 @@ class Treemap(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -8019,11 +8019,11 @@ class Treemap(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available. variables `currentPath`, `root`, `entry`,
@@ -8091,7 +8091,7 @@ class Treemap(_BaseTraceType):
                 squarifyratio
                     When using "squarify" `packing` algorithm,
                     according to https://github.com/d3/d3-hierarchy
-                    /blob/master/README.md#squarify_ratio this
+                    /blob/main/README.md#squarify_ratio this
                     option specifies the desired aspect ratio of
                     the generated rectangles. The ratio must be
                     specified as a number greater than or equal to
@@ -8288,12 +8288,12 @@ class Treemap(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -8402,12 +8402,12 @@ class Treemap(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables
@@ -8552,12 +8552,12 @@ class Treemap(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -8666,12 +8666,12 @@ class Treemap(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables
@@ -8940,7 +8940,7 @@ class Table(_BaseTraceType):
                     formatting mini-language which is similar to
                     those of Python. See
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                 formatsrc
                     Sets the source reference on plot.ly for
                     format .
@@ -9178,7 +9178,7 @@ class Table(_BaseTraceType):
                     formatting mini-language which is similar to
                     those of Python. See
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                 formatsrc
                     Sets the source reference on plot.ly for
                     format .
@@ -10187,10 +10187,10 @@ class Surface(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -10579,11 +10579,11 @@ class Surface(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -11438,12 +11438,12 @@ class Surface(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -11728,12 +11728,12 @@ class Surface(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -12317,11 +12317,11 @@ class Sunburst(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -13088,11 +13088,11 @@ class Sunburst(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available. variables `currentPath`, `root`, `entry`,
@@ -13308,12 +13308,12 @@ class Sunburst(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -13420,12 +13420,12 @@ class Sunburst(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables
@@ -13564,12 +13564,12 @@ class Sunburst(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -13676,12 +13676,12 @@ class Sunburst(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables
@@ -14178,10 +14178,10 @@ class Streamtube(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -14494,11 +14494,11 @@ class Streamtube(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -15397,12 +15397,12 @@ class Streamtube(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -15683,12 +15683,12 @@ class Streamtube(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -16305,11 +16305,11 @@ class Splom(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -17105,12 +17105,12 @@ class Splom(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -17329,12 +17329,12 @@ class Splom(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -18076,11 +18076,11 @@ class Scatterternary(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -18869,11 +18869,11 @@ class Scatterternary(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available. variables `a`, `b`, `c` and `text`.
@@ -19118,12 +19118,12 @@ class Scatterternary(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -19242,12 +19242,12 @@ class Scatterternary(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `a`, `b`, `c`
@@ -19429,12 +19429,12 @@ class Scatterternary(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -19553,12 +19553,12 @@ class Scatterternary(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `a`, `b`, `c`
@@ -20130,11 +20130,11 @@ class Scatterpolargl(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -20943,11 +20943,11 @@ class Scatterpolargl(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available. variables `r`, `theta` and `text`.
@@ -21257,12 +21257,12 @@ class Scatterpolargl(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -21382,12 +21382,12 @@ class Scatterpolargl(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `r`, `theta`
@@ -21565,12 +21565,12 @@ class Scatterpolargl(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -21690,12 +21690,12 @@ class Scatterpolargl(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `r`, `theta`
@@ -22315,11 +22315,11 @@ class Scatterpolar(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -23142,11 +23142,11 @@ class Scatterpolar(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available. variables `r`, `theta` and `text`.
@@ -23456,12 +23456,12 @@ class Scatterpolar(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -23581,12 +23581,12 @@ class Scatterpolar(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `r`, `theta`
@@ -23767,12 +23767,12 @@ class Scatterpolar(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -23892,12 +23892,12 @@ class Scatterpolar(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `r`, `theta`
@@ -24448,11 +24448,11 @@ class Scattermapbox(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -25233,11 +25233,11 @@ class Scattermapbox(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available. variables `lat`, `lon` and `text`.
@@ -25442,12 +25442,12 @@ class Scattermapbox(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -25564,12 +25564,12 @@ class Scattermapbox(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `lat`, `lon`
@@ -25710,12 +25710,12 @@ class Scattermapbox(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -25832,12 +25832,12 @@ class Scattermapbox(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `lat`, `lon`
@@ -26548,11 +26548,11 @@ class Scattergl(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -27267,11 +27267,11 @@ class Scattergl(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available.
@@ -27720,12 +27720,12 @@ class Scattergl(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -27827,12 +27827,12 @@ class Scattergl(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available.
@@ -28034,12 +28034,12 @@ class Scattergl(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -28141,12 +28141,12 @@ class Scattergl(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available.
@@ -28719,11 +28719,11 @@ class Scattergeo(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -29592,11 +29592,11 @@ class Scattergeo(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available. variables `lat`, `lon`, `location` and `text`.
@@ -29804,12 +29804,12 @@ class Scattergeo(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -29934,12 +29934,12 @@ class Scattergeo(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `lat`, `lon`,
@@ -30084,12 +30084,12 @@ class Scattergeo(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -30214,12 +30214,12 @@ class Scattergeo(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `lat`, `lon`,
@@ -30854,11 +30854,11 @@ class Scattercarpet(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -31595,11 +31595,11 @@ class Scattercarpet(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available. variables `a`, `b` and `text`.
@@ -31876,12 +31876,12 @@ class Scattercarpet(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -31987,12 +31987,12 @@ class Scattercarpet(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `a`, `b` and
@@ -32163,12 +32163,12 @@ class Scattercarpet(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -32274,12 +32274,12 @@ class Scattercarpet(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `a`, `b` and
@@ -32949,11 +32949,11 @@ class Scatter3d(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -33831,11 +33831,11 @@ class Scatter3d(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available.
@@ -34198,12 +34198,12 @@ class Scatter3d(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -34316,12 +34316,12 @@ class Scatter3d(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available.
@@ -34479,12 +34479,12 @@ class Scatter3d(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -34597,12 +34597,12 @@ class Scatter3d(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available.
@@ -35420,11 +35420,11 @@ class Scatter(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -36316,11 +36316,11 @@ class Scatter(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available.
@@ -36812,12 +36812,12 @@ class Scatter(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -36965,12 +36965,12 @@ class Scatter(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available.
@@ -37209,12 +37209,12 @@ class Scatter(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -37362,12 +37362,12 @@ class Scatter(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available.
@@ -37968,13 +37968,13 @@ class Sankey(_BaseTraceType):
                     syntax %{variable:d3-format}, for example
                     "Price: %{y:$.2f}".
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     for details on the formatting syntax. Dates are
                     formatted using d3-time-format's syntax
                     %{variable|d3-time-format}, for example "Day:
                     %{2019-01-01|%A}".
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     for details on the date formatting syntax. The
                     variables available in `hovertemplate` are the
                     ones emitted as event data described at this
@@ -38146,13 +38146,13 @@ class Sankey(_BaseTraceType):
                     syntax %{variable:d3-format}, for example
                     "Price: %{y:$.2f}".
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     for details on the formatting syntax. Dates are
                     formatted using d3-time-format's syntax
                     %{variable|d3-time-format}, for example "Day:
                     %{2019-01-01|%A}".
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     for details on the date formatting syntax. The
                     variables available in `hovertemplate` are the
                     ones emitted as event data described at this
@@ -38386,7 +38386,7 @@ class Sankey(_BaseTraceType):
         Sets the value formatting rule using d3 formatting mini-
         language which is similar to those of Python. See
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format
+        reference/blob/main/Formatting.md#d3_format
     
         The 'valueformat' property is a string and must be specified as:
           - A string
@@ -38560,7 +38560,7 @@ class Sankey(_BaseTraceType):
             Sets the value formatting rule using d3 formatting
             mini-language which is similar to those of Python. See
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         valuesuffix
             Adds a unit to follow the value in the hover tooltip.
             Add a space if a separation is necessary from the
@@ -38708,7 +38708,7 @@ class Sankey(_BaseTraceType):
             Sets the value formatting rule using d3 formatting
             mini-language which is similar to those of Python. See
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         valuesuffix
             Adds a unit to follow the value in the hover tooltip.
             Add a space if a separation is necessary from the
@@ -40482,11 +40482,11 @@ class Pie(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -41282,11 +41282,11 @@ class Pie(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available. variables `label`, `color`, `value`, `percent` and
@@ -41620,12 +41620,12 @@ class Pie(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -41748,12 +41748,12 @@ class Pie(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `label`,
@@ -41917,12 +41917,12 @@ class Pie(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -42045,12 +42045,12 @@ class Pie(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `label`,
@@ -42420,10 +42420,10 @@ class Parcoords(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -43702,11 +43702,11 @@ class Parcats(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -43874,13 +43874,13 @@ class Parcats(_BaseTraceType):
                     syntax %{variable:d3-format}, for example
                     "Price: %{y:$.2f}".
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     for details on the formatting syntax. Dates are
                     formatted using d3-time-format's syntax
                     %{variable|d3-time-format}, for example "Day:
                     %{2019-01-01|%A}".
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     for details on the date formatting syntax. The
                     variables available in `hovertemplate` are the
                     ones emitted as event data described at this
@@ -44231,12 +44231,12 @@ class Parcats(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -44394,12 +44394,12 @@ class Parcats(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -46447,10 +46447,10 @@ class Mesh3d(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -46881,11 +46881,11 @@ class Mesh3d(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -47961,12 +47961,12 @@ class Mesh3d(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -48332,12 +48332,12 @@ class Mesh3d(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -49058,10 +49058,10 @@ class Isosurface(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -49427,11 +49427,11 @@ class Isosurface(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -50378,12 +50378,12 @@ class Isosurface(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -50671,12 +50671,12 @@ class Isosurface(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -51125,7 +51125,7 @@ class Indicator(_BaseTraceType):
                     formatting mini-language which is similar to
                     those of Python. See
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
 
         Returns
         -------
@@ -51388,7 +51388,7 @@ class Indicator(_BaseTraceType):
                     formatting mini-language which is similar to
                     those of Python. See
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
 
         Returns
         -------
@@ -52137,11 +52137,11 @@ class Image(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -52754,12 +52754,12 @@ class Image(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -52957,12 +52957,12 @@ class Image(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -53508,10 +53508,10 @@ class Histogram2dContour(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -53701,7 +53701,7 @@ class Histogram2dContour(_BaseTraceType):
                     formatting mini-language which is very similar
                     to Python, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                 operation
                     Sets the constraint operation. "=" keeps
                     regions equal to `value` "<" and "<=" keep
@@ -53973,11 +53973,11 @@ class Histogram2dContour(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -54887,7 +54887,7 @@ class Histogram2dContour(_BaseTraceType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. See:
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format
+        reference/blob/main/Formatting.md#d3_format
     
         The 'zhoverformat' property is a string and must be specified as:
           - A string
@@ -55107,12 +55107,12 @@ class Histogram2dContour(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -55274,7 +55274,7 @@ class Histogram2dContour(_BaseTraceType):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -55471,12 +55471,12 @@ class Histogram2dContour(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -55638,7 +55638,7 @@ class Histogram2dContour(_BaseTraceType):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -56146,10 +56146,10 @@ class Histogram2d(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -56523,11 +56523,11 @@ class Histogram2d(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -57371,7 +57371,7 @@ class Histogram2d(_BaseTraceType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. See:
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format
+        reference/blob/main/Formatting.md#d3_format
     
         The 'zhoverformat' property is a string and must be specified as:
           - A string
@@ -57604,12 +57604,12 @@ class Histogram2d(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -57759,7 +57759,7 @@ class Histogram2d(_BaseTraceType):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -57947,12 +57947,12 @@ class Histogram2d(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -58102,7 +58102,7 @@ class Histogram2d(_BaseTraceType):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -58868,11 +58868,11 @@ class Histogram(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -60002,12 +60002,12 @@ class Histogram(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -60315,12 +60315,12 @@ class Histogram(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -60868,10 +60868,10 @@ class Heatmapgl(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -62709,10 +62709,10 @@ class Heatmap(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -63109,11 +63109,11 @@ class Heatmap(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -63904,7 +63904,7 @@ class Heatmap(_BaseTraceType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. See:
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format
+        reference/blob/main/Formatting.md#d3_format
     
         The 'zhoverformat' property is a string and must be specified as:
           - A string
@@ -64108,12 +64108,12 @@ class Heatmap(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -64257,7 +64257,7 @@ class Heatmap(_BaseTraceType):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -64428,12 +64428,12 @@ class Heatmap(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -64577,7 +64577,7 @@ class Heatmap(_BaseTraceType):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -65078,11 +65078,11 @@ class Funnelarea(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -65737,11 +65737,11 @@ class Funnelarea(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available. variables `label`, `color`, `value`, `text` and
@@ -65990,12 +65990,12 @@ class Funnelarea(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -66101,12 +66101,12 @@ class Funnelarea(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `label`,
@@ -66246,12 +66246,12 @@ class Funnelarea(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -66357,12 +66357,12 @@ class Funnelarea(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `label`,
@@ -66894,11 +66894,11 @@ class Funnel(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -67756,11 +67756,11 @@ class Funnel(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available. variables `percentInitial`, `percentPrevious`,
@@ -68132,12 +68132,12 @@ class Funnel(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -68273,12 +68273,12 @@ class Funnel(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables
@@ -68461,12 +68461,12 @@ class Funnel(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -68602,12 +68602,12 @@ class Funnel(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables
@@ -69101,10 +69101,10 @@ class Densitymapbox(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -69418,11 +69418,11 @@ class Densitymapbox(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -70199,12 +70199,12 @@ class Densitymapbox(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -70462,12 +70462,12 @@ class Densitymapbox(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -71191,10 +71191,10 @@ class Contourcarpet(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -71381,7 +71381,7 @@ class Contourcarpet(_BaseTraceType):
                     formatting mini-language which is very similar
                     to Python, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                 operation
                     Sets the constraint operation. "=" keeps
                     regions equal to `value` "<" and "<=" keep
@@ -73160,10 +73160,10 @@ class Contour(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -73373,7 +73373,7 @@ class Contour(_BaseTraceType):
                     formatting mini-language which is very similar
                     to Python, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                 operation
                     Sets the constraint operation. "=" keeps
                     regions equal to `value` "<" and "<=" keep
@@ -73709,11 +73709,11 @@ class Contour(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -74573,7 +74573,7 @@ class Contour(_BaseTraceType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. See:
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format
+        reference/blob/main/Formatting.md#d3_format
     
         The 'zhoverformat' property is a string and must be specified as:
           - A string
@@ -74769,12 +74769,12 @@ class Contour(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -74930,7 +74930,7 @@ class Contour(_BaseTraceType):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -75106,12 +75106,12 @@ class Contour(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -75267,7 +75267,7 @@ class Contour(_BaseTraceType):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -75815,10 +75815,10 @@ class Cone(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -76129,11 +76129,11 @@ class Cone(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -77050,12 +77050,12 @@ class Cone(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -77350,12 +77350,12 @@ class Cone(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -77922,10 +77922,10 @@ class Choroplethmapbox(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -78262,11 +78262,11 @@ class Choroplethmapbox(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -79049,12 +79049,12 @@ class Choroplethmapbox(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -79311,12 +79311,12 @@ class Choroplethmapbox(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -79822,10 +79822,10 @@ class Choropleth(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -80163,11 +80163,11 @@ class Choropleth(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -80939,12 +80939,12 @@ class Choropleth(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -81191,12 +81191,12 @@ class Choropleth(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -81719,7 +81719,7 @@ class Carpet(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:  We add one item to d3's
                     date formatter: "%{n}f" for fractional seconds
                     with n digits. For example, *2016-10-13
@@ -82016,7 +82016,7 @@ class Carpet(_BaseTraceType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:  We add one item to d3's
                     date formatter: "%{n}f" for fractional seconds
                     with n digits. For example, *2016-10-13
@@ -84996,11 +84996,11 @@ class Box(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -86035,12 +86035,12 @@ class Box(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -86341,12 +86341,12 @@ class Box(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -86981,11 +86981,11 @@ class Barpolar(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -87912,12 +87912,12 @@ class Barpolar(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -88151,12 +88151,12 @@ class Barpolar(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -88954,11 +88954,11 @@ class Bar(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -89901,11 +89901,11 @@ class Bar(_BaseTraceType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. Every attributes that can be
         specified per-point (the ones that are `arrayOk: true`) are
         available. variables `value` and `label`.
@@ -90405,12 +90405,12 @@ class Bar(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -90552,12 +90552,12 @@ class Bar(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `value` and
@@ -90770,12 +90770,12 @@ class Bar(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -90917,12 +90917,12 @@ class Bar(_BaseTraceType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `value` and
@@ -95806,10 +95806,10 @@ class Layout(_BaseLayoutType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -96006,10 +96006,10 @@ class Layout(_BaseLayoutType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -96248,10 +96248,10 @@ class Layout(_BaseLayoutType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -96442,10 +96442,10 @@ class Layout(_BaseLayoutType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/_figure.py
+++ b/env/Lib/site-packages/plotly/graph_objs/_figure.py
@@ -911,12 +911,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -1058,12 +1058,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `value` and
@@ -1323,12 +1323,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -1648,12 +1648,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -2531,12 +2531,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -2844,12 +2844,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -3180,12 +3180,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -3560,12 +3560,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -3721,7 +3721,7 @@ class Figure(BaseFigure):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -4285,12 +4285,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -4604,12 +4604,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -4745,12 +4745,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables
@@ -4988,12 +4988,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -5099,12 +5099,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `label`,
@@ -5357,12 +5357,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -5506,7 +5506,7 @@ class Figure(BaseFigure):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -6063,12 +6063,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -6466,12 +6466,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -6621,7 +6621,7 @@ class Figure(BaseFigure):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -6898,12 +6898,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -7065,7 +7065,7 @@ class Figure(BaseFigure):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -7247,12 +7247,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -7736,12 +7736,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -8130,12 +8130,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -8740,12 +8740,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -9126,12 +9126,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -9254,12 +9254,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `label`,
@@ -9767,7 +9767,7 @@ class Figure(BaseFigure):
             Sets the value formatting rule using d3 formatting
             mini-language which is similar to those of Python. See
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         valuesuffix
             Adds a unit to follow the value in the hover tooltip.
             Add a space if a separation is necessary from the
@@ -9984,12 +9984,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -10137,12 +10137,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available.
@@ -10402,12 +10402,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -10520,12 +10520,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available.
@@ -10763,12 +10763,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -10874,12 +10874,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `a`, `b` and
@@ -11103,12 +11103,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -11233,12 +11233,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `lat`, `lon`,
@@ -11471,12 +11471,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -11578,12 +11578,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available.
@@ -11828,12 +11828,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -11950,12 +11950,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `lat`, `lon`
@@ -12181,12 +12181,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -12306,12 +12306,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `r`, `theta`
@@ -12552,12 +12552,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -12677,12 +12677,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `r`, `theta`
@@ -12936,12 +12936,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -13060,12 +13060,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `a`, `b`, `c`
@@ -13256,12 +13256,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -13579,12 +13579,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -13880,12 +13880,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -13992,12 +13992,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables
@@ -14248,12 +14248,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -14715,12 +14715,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -14829,12 +14829,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables
@@ -15055,12 +15055,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -15499,12 +15499,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -15848,12 +15848,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -15994,12 +15994,12 @@ class Figure(BaseFigure):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `initial`,

--- a/env/Lib/site-packages/plotly/graph_objs/_figurewidget.py
+++ b/env/Lib/site-packages/plotly/graph_objs/_figurewidget.py
@@ -911,12 +911,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -1058,12 +1058,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `value` and
@@ -1323,12 +1323,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -1648,12 +1648,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -2531,12 +2531,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -2844,12 +2844,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -3180,12 +3180,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -3560,12 +3560,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -3721,7 +3721,7 @@ class FigureWidget(BaseFigureWidget):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -4285,12 +4285,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -4604,12 +4604,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -4745,12 +4745,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables
@@ -4988,12 +4988,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -5099,12 +5099,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `label`,
@@ -5357,12 +5357,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -5506,7 +5506,7 @@ class FigureWidget(BaseFigureWidget):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -6063,12 +6063,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -6466,12 +6466,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -6621,7 +6621,7 @@ class FigureWidget(BaseFigureWidget):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -6898,12 +6898,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -7065,7 +7065,7 @@ class FigureWidget(BaseFigureWidget):
             Sets the hover text formatting rule using d3 formatting
             mini-languages which are very similar to those in
             Python. See: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         zmax
             Sets the upper bound of the color domain. Value should
             have the same units as in `z` and if set, `zmin` must
@@ -7247,12 +7247,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -7736,12 +7736,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -8130,12 +8130,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -8740,12 +8740,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -9126,12 +9126,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -9254,12 +9254,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `label`,
@@ -9767,7 +9767,7 @@ class FigureWidget(BaseFigureWidget):
             Sets the value formatting rule using d3 formatting
             mini-language which is similar to those of Python. See
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         valuesuffix
             Adds a unit to follow the value in the hover tooltip.
             Add a space if a separation is necessary from the
@@ -9984,12 +9984,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -10137,12 +10137,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available.
@@ -10402,12 +10402,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -10520,12 +10520,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available.
@@ -10763,12 +10763,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -10874,12 +10874,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `a`, `b` and
@@ -11103,12 +11103,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -11233,12 +11233,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `lat`, `lon`,
@@ -11471,12 +11471,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -11578,12 +11578,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available.
@@ -11828,12 +11828,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -11950,12 +11950,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `lat`, `lon`
@@ -12181,12 +12181,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -12306,12 +12306,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `r`, `theta`
@@ -12552,12 +12552,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -12677,12 +12677,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `r`, `theta`
@@ -12936,12 +12936,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -13060,12 +13060,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `a`, `b`, `c`
@@ -13256,12 +13256,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -13579,12 +13579,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -13880,12 +13880,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -13992,12 +13992,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables
@@ -14248,12 +14248,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -14715,12 +14715,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -14829,12 +14829,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables
@@ -15055,12 +15055,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -15499,12 +15499,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -15848,12 +15848,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -15994,12 +15994,12 @@ class FigureWidget(BaseFigureWidget):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. Every attributes
             that can be specified per-point (the ones that are
             `arrayOk: true`) are available. variables `initial`,

--- a/env/Lib/site-packages/plotly/graph_objs/bar/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/bar/__init__.py
@@ -1424,10 +1424,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/bar/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/bar/marker/__init__.py
@@ -1302,9 +1302,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1973,9 +1973,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2223,9 +2223,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/barpolar/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/barpolar/__init__.py
@@ -782,10 +782,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/barpolar/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/barpolar/marker/__init__.py
@@ -1302,9 +1302,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1975,9 +1975,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2226,9 +2226,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/carpet/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/carpet/__init__.py
@@ -1525,7 +1525,7 @@ class Baxis(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see:  We add one item to d3's date formatter: "%{n}f" for
         fractional seconds with n digits. For example, *2016-10-13
         09:15:23.456* with tickformat "%H~%M~%S.%2f" would display
@@ -2061,7 +2061,7 @@ class Baxis(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see:  We add one item to d3's date formatter:
             "%{n}f" for fractional seconds with n digits. For
             example, *2016-10-13 09:15:23.456* with tickformat
@@ -2330,7 +2330,7 @@ class Baxis(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see:  We add one item to d3's date formatter:
             "%{n}f" for fractional seconds with n digits. For
             example, *2016-10-13 09:15:23.456* with tickformat
@@ -3758,7 +3758,7 @@ class Aaxis(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see:  We add one item to d3's date formatter: "%{n}f" for
         fractional seconds with n digits. For example, *2016-10-13
         09:15:23.456* with tickformat "%H~%M~%S.%2f" would display
@@ -4294,7 +4294,7 @@ class Aaxis(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see:  We add one item to d3's date formatter:
             "%{n}f" for fractional seconds with n digits. For
             example, *2016-10-13 09:15:23.456* with tickformat
@@ -4563,7 +4563,7 @@ class Aaxis(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see:  We add one item to d3's date formatter:
             "%{n}f" for fractional seconds with n digits. For
             example, *2016-10-13 09:15:23.456* with tickformat

--- a/env/Lib/site-packages/plotly/graph_objs/choropleth/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/choropleth/__init__.py
@@ -1683,9 +1683,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2354,9 +2354,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2604,9 +2604,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/choroplethmapbox/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/choroplethmapbox/__init__.py
@@ -1688,9 +1688,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2361,9 +2361,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2613,9 +2613,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/cone/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/cone/__init__.py
@@ -1755,9 +1755,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2427,9 +2427,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2677,9 +2677,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/contour/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/contour/__init__.py
@@ -969,7 +969,7 @@ class Contours(_BaseTraceHierarchyType):
         Sets the contour label formatting rule using d3 formatting
         mini-language which is very similar to Python, see:
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format
+        reference/blob/main/Formatting.md#d3_format
     
         The 'labelformat' property is a string and must be specified as:
           - A string
@@ -1175,7 +1175,7 @@ class Contours(_BaseTraceHierarchyType):
             Sets the contour label formatting rule using d3
             formatting mini-language which is very similar to
             Python, see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         operation
             Sets the constraint operation. "=" keeps regions equal
             to `value` "<" and "<=" keep regions less than `value`
@@ -1256,7 +1256,7 @@ class Contours(_BaseTraceHierarchyType):
             Sets the contour label formatting rule using d3
             formatting mini-language which is very similar to
             Python, see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         operation
             Sets the constraint operation. "=" keeps regions equal
             to `value` "<" and "<=" keep regions less than `value`
@@ -2043,9 +2043,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2715,9 +2715,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2965,9 +2965,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/contourcarpet/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/contourcarpet/__init__.py
@@ -492,7 +492,7 @@ class Contours(_BaseTraceHierarchyType):
         Sets the contour label formatting rule using d3 formatting
         mini-language which is very similar to Python, see:
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format
+        reference/blob/main/Formatting.md#d3_format
     
         The 'labelformat' property is a string and must be specified as:
           - A string
@@ -697,7 +697,7 @@ class Contours(_BaseTraceHierarchyType):
             Sets the contour label formatting rule using d3
             formatting mini-language which is very similar to
             Python, see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         operation
             Sets the constraint operation. "=" keeps regions equal
             to `value` "<" and "<=" keep regions less than `value`
@@ -777,7 +777,7 @@ class Contours(_BaseTraceHierarchyType):
             Sets the contour label formatting rule using d3
             formatting mini-language which is very similar to
             Python, see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         operation
             Sets the constraint operation. "=" keeps regions equal
             to `value` "<" and "<=" keep regions less than `value`
@@ -1564,9 +1564,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2237,9 +2237,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2487,9 +2487,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/densitymapbox/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/densitymapbox/__init__.py
@@ -1287,9 +1287,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1960,9 +1960,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2210,9 +2210,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/funnel/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/funnel/__init__.py
@@ -1129,10 +1129,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/funnel/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/funnel/marker/__init__.py
@@ -1302,9 +1302,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1975,9 +1975,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2225,9 +2225,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/heatmap/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/heatmap/__init__.py
@@ -1286,9 +1286,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1958,9 +1958,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2208,9 +2208,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/heatmapgl/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/heatmapgl/__init__.py
@@ -1286,9 +1286,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1957,9 +1957,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2207,9 +2207,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/histogram/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/histogram/__init__.py
@@ -1266,10 +1266,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/histogram/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/histogram/marker/__init__.py
@@ -1302,9 +1302,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1975,9 +1975,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2227,9 +2227,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/histogram2d/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/histogram2d/__init__.py
@@ -1852,9 +1852,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2524,9 +2524,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2774,9 +2774,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/histogram2dcontour/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/histogram2dcontour/__init__.py
@@ -1535,7 +1535,7 @@ class Contours(_BaseTraceHierarchyType):
         Sets the contour label formatting rule using d3 formatting
         mini-language which is very similar to Python, see:
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format
+        reference/blob/main/Formatting.md#d3_format
     
         The 'labelformat' property is a string and must be specified as:
           - A string
@@ -1741,7 +1741,7 @@ class Contours(_BaseTraceHierarchyType):
             Sets the contour label formatting rule using d3
             formatting mini-language which is very similar to
             Python, see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         operation
             Sets the constraint operation. "=" keeps regions equal
             to `value` "<" and "<=" keep regions less than `value`
@@ -1823,7 +1823,7 @@ class Contours(_BaseTraceHierarchyType):
             Sets the contour label formatting rule using d3
             formatting mini-language which is very similar to
             Python, see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         operation
             Sets the constraint operation. "=" keeps regions equal
             to `value` "<" and "<=" keep regions less than `value`
@@ -2610,9 +2610,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -3283,9 +3283,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -3536,9 +3536,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/indicator/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/indicator/__init__.py
@@ -428,7 +428,7 @@ class Number(_BaseTraceHierarchyType):
         Sets the value formatting rule using d3 formatting mini-
         language which is similar to those of Python. See
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format
+        reference/blob/main/Formatting.md#d3_format
     
         The 'valueformat' property is a string and must be specified as:
           - A string
@@ -465,7 +465,7 @@ class Number(_BaseTraceHierarchyType):
             Sets the value formatting rule using d3 formatting
             mini-language which is similar to those of Python. See
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         """
 
     def __init__(
@@ -489,7 +489,7 @@ class Number(_BaseTraceHierarchyType):
             Sets the value formatting rule using d3 formatting
             mini-language which is similar to those of Python. See
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
 
         Returns
         -------
@@ -654,10 +654,10 @@ class Gauge(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -1580,7 +1580,7 @@ class Delta(_BaseTraceHierarchyType):
         Sets the value formatting rule using d3 formatting mini-
         language which is similar to those of Python. See
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format
+        reference/blob/main/Formatting.md#d3_format
     
         The 'valueformat' property is a string and must be specified as:
           - A string
@@ -1626,7 +1626,7 @@ class Delta(_BaseTraceHierarchyType):
             Sets the value formatting rule using d3 formatting
             mini-language which is similar to those of Python. See
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         """
 
     def __init__(
@@ -1668,7 +1668,7 @@ class Delta(_BaseTraceHierarchyType):
             Sets the value formatting rule using d3 formatting
             mini-language which is similar to those of Python. See
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
 
         Returns
         -------

--- a/env/Lib/site-packages/plotly/graph_objs/indicator/gauge/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/indicator/gauge/__init__.py
@@ -1120,9 +1120,9 @@ class Axis(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1552,9 +1552,9 @@ class Axis(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1725,9 +1725,9 @@ class Axis(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/isosurface/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/isosurface/__init__.py
@@ -2556,9 +2556,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -3227,9 +3227,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -3477,9 +3477,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/layout/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/layout/__init__.py
@@ -571,9 +571,9 @@ class YAxis(_BaseLayoutHierarchyType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1471,9 +1471,9 @@ class YAxis(_BaseLayoutHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2198,9 +2198,9 @@ class YAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2375,9 +2375,9 @@ class YAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2657,9 +2657,9 @@ class YAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2834,9 +2834,9 @@ class YAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -3760,9 +3760,9 @@ class XAxis(_BaseLayoutHierarchyType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -4787,9 +4787,9 @@ class XAxis(_BaseLayoutHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -5514,9 +5514,9 @@ class XAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -5697,9 +5697,9 @@ class XAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -5981,9 +5981,9 @@ class XAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -6164,9 +6164,9 @@ class XAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -8102,10 +8102,10 @@ class Ternary(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -8186,10 +8186,10 @@ class Ternary(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -8331,10 +8331,10 @@ class Ternary(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -8415,10 +8415,10 @@ class Ternary(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -8619,10 +8619,10 @@ class Ternary(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -8703,10 +8703,10 @@ class Ternary(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -11975,10 +11975,10 @@ class Scene(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -12089,10 +12089,10 @@ class Scene(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -12287,10 +12287,10 @@ class Scene(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -12401,10 +12401,10 @@ class Scene(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -12599,10 +12599,10 @@ class Scene(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -12713,10 +12713,10 @@ class Scene(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -13621,10 +13621,10 @@ class Polar(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -13716,10 +13716,10 @@ class Polar(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -14098,10 +14098,10 @@ class Polar(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -14199,10 +14199,10 @@ class Polar(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -20181,10 +20181,10 @@ class Coloraxis(_BaseLayoutHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/layout/coloraxis/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/layout/coloraxis/__init__.py
@@ -669,9 +669,9 @@ class ColorBar(_BaseLayoutHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1342,9 +1342,9 @@ class ColorBar(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1594,9 +1594,9 @@ class ColorBar(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/layout/polar/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/layout/polar/__init__.py
@@ -374,9 +374,9 @@ class RadialAxis(_BaseLayoutHierarchyType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -914,9 +914,9 @@ class RadialAxis(_BaseLayoutHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1477,9 +1477,9 @@ class RadialAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1568,9 +1568,9 @@ class RadialAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1788,9 +1788,9 @@ class RadialAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1879,9 +1879,9 @@ class RadialAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2677,9 +2677,9 @@ class AngularAxis(_BaseLayoutHierarchyType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -3210,9 +3210,9 @@ class AngularAxis(_BaseLayoutHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -3677,9 +3677,9 @@ class AngularAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -3762,9 +3762,9 @@ class AngularAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -3953,9 +3953,9 @@ class AngularAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -4038,9 +4038,9 @@ class AngularAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/layout/scene/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/layout/scene/__init__.py
@@ -407,9 +407,9 @@ class ZAxis(_BaseLayoutHierarchyType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1086,9 +1086,9 @@ class ZAxis(_BaseLayoutHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1725,9 +1725,9 @@ class ZAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1829,9 +1829,9 @@ class ZAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2054,9 +2054,9 @@ class ZAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2158,9 +2158,9 @@ class ZAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2858,9 +2858,9 @@ class YAxis(_BaseLayoutHierarchyType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -3537,9 +3537,9 @@ class YAxis(_BaseLayoutHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -4176,9 +4176,9 @@ class YAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -4280,9 +4280,9 @@ class YAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -4505,9 +4505,9 @@ class YAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -4609,9 +4609,9 @@ class YAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -5309,9 +5309,9 @@ class XAxis(_BaseLayoutHierarchyType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -5988,9 +5988,9 @@ class XAxis(_BaseLayoutHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -6627,9 +6627,9 @@ class XAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -6731,9 +6731,9 @@ class XAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -6956,9 +6956,9 @@ class XAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -7060,9 +7060,9 @@ class XAxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/layout/ternary/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/layout/ternary/__init__.py
@@ -422,9 +422,9 @@ class Caxis(_BaseLayoutHierarchyType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -907,9 +907,9 @@ class Caxis(_BaseLayoutHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1385,9 +1385,9 @@ class Caxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1461,9 +1461,9 @@ class Caxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1621,9 +1621,9 @@ class Caxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1697,9 +1697,9 @@ class Caxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2141,9 +2141,9 @@ class Baxis(_BaseLayoutHierarchyType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2626,9 +2626,9 @@ class Baxis(_BaseLayoutHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -3104,9 +3104,9 @@ class Baxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -3180,9 +3180,9 @@ class Baxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -3340,9 +3340,9 @@ class Baxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -3416,9 +3416,9 @@ class Baxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -3860,9 +3860,9 @@ class Aaxis(_BaseLayoutHierarchyType):
         Sets the hover text formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -4345,9 +4345,9 @@ class Aaxis(_BaseLayoutHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -4823,9 +4823,9 @@ class Aaxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -4899,9 +4899,9 @@ class Aaxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -5059,9 +5059,9 @@ class Aaxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -5135,9 +5135,9 @@ class Aaxis(_BaseLayoutHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/mesh3d/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/mesh3d/__init__.py
@@ -1949,9 +1949,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2621,9 +2621,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2871,9 +2871,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/parcats/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/parcats/__init__.py
@@ -713,10 +713,10 @@ class Line(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -903,11 +903,11 @@ class Line(_BaseTraceHierarchyType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -1083,12 +1083,12 @@ class Line(_BaseTraceHierarchyType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -1215,12 +1215,12 @@ class Line(_BaseTraceHierarchyType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link

--- a/env/Lib/site-packages/plotly/graph_objs/parcats/line/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/parcats/line/__init__.py
@@ -669,9 +669,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1342,9 +1342,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1592,9 +1592,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/parcoords/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/parcoords/__init__.py
@@ -940,10 +940,10 @@ class Line(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -2039,9 +2039,9 @@ class Dimension(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2256,9 +2256,9 @@ class Dimension(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2356,9 +2356,9 @@ class Dimension(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/parcoords/line/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/parcoords/line/__init__.py
@@ -669,9 +669,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1342,9 +1342,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1593,9 +1593,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/sankey/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/sankey/__init__.py
@@ -575,11 +575,11 @@ class Node(_BaseTraceHierarchyType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -860,12 +860,12 @@ class Node(_BaseTraceHierarchyType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -960,12 +960,12 @@ class Node(_BaseTraceHierarchyType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -1371,11 +1371,11 @@ class Link(_BaseTraceHierarchyType):
         %{y}". Numbers are formatted using d3-format's syntax
         %{variable:d3-format}, for example "Price: %{y:$.2f}".
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format for details on
+        reference/blob/main/Formatting.md#d3_format for details on
         the formatting syntax. Dates are formatted using d3-time-
         format's syntax %{variable|d3-time-format}, for example "Day:
         %{2019-01-01|%A}". https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format for details on
+        reference/blob/main/Time-Formatting.md#format for details on
         the date formatting syntax. The variables available in
         `hovertemplate` are the ones emitted as event data described at
         this link https://plot.ly/javascript/plotlyjs-events/#event-
@@ -1660,12 +1660,12 @@ class Link(_BaseTraceHierarchyType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link
@@ -1765,12 +1765,12 @@ class Link(_BaseTraceHierarchyType):
             for example "y: %{y}". Numbers are formatted using
             d3-format's syntax %{variable:d3-format}, for example
             "Price: %{y:$.2f}". https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format for
+            reference/blob/main/Formatting.md#d3_format for
             details on the formatting syntax. Dates are formatted
             using d3-time-format's syntax %{variable|d3-time-
             format}, for example "Day: %{2019-01-01|%A}".
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format for
+            reference/blob/main/Time-Formatting.md#format for
             details on the date formatting syntax. The variables
             available in `hovertemplate` are the ones emitted as
             event data described at this link

--- a/env/Lib/site-packages/plotly/graph_objs/scatter/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scatter/__init__.py
@@ -1108,10 +1108,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/scatter/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scatter/marker/__init__.py
@@ -1534,9 +1534,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2207,9 +2207,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2458,9 +2458,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/scatter3d/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scatter3d/__init__.py
@@ -974,10 +974,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with
@@ -2196,10 +2196,10 @@ class Line(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/scatter3d/line/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scatter3d/line/__init__.py
@@ -669,9 +669,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1342,9 +1342,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1593,9 +1593,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/scatter3d/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scatter3d/marker/__init__.py
@@ -1273,9 +1273,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1946,9 +1946,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2198,9 +2198,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/scattercarpet/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scattercarpet/__init__.py
@@ -1109,10 +1109,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/scattercarpet/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scattercarpet/marker/__init__.py
@@ -1535,9 +1535,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2208,9 +2208,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2461,9 +2461,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/scattergeo/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scattergeo/__init__.py
@@ -1108,10 +1108,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/scattergeo/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scattergeo/marker/__init__.py
@@ -1534,9 +1534,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2207,9 +2207,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2460,9 +2460,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/scattergl/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scattergl/__init__.py
@@ -1108,10 +1108,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/scattergl/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scattergl/marker/__init__.py
@@ -1302,9 +1302,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1975,9 +1975,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2227,9 +2227,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/scattermapbox/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scattermapbox/__init__.py
@@ -946,10 +946,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/scattermapbox/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scattermapbox/marker/__init__.py
@@ -669,9 +669,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1342,9 +1342,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1595,9 +1595,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/scatterpolar/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scatterpolar/__init__.py
@@ -1109,10 +1109,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/scatterpolar/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scatterpolar/marker/__init__.py
@@ -1535,9 +1535,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2208,9 +2208,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2461,9 +2461,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/scatterpolargl/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scatterpolargl/__init__.py
@@ -1111,10 +1111,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/scatterpolargl/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scatterpolargl/marker/__init__.py
@@ -1303,9 +1303,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1977,9 +1977,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2230,9 +2230,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/scatterternary/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scatterternary/__init__.py
@@ -1111,10 +1111,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/scatterternary/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/scatterternary/marker/__init__.py
@@ -1535,9 +1535,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2209,9 +2209,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2462,9 +2462,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/splom/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/splom/__init__.py
@@ -716,10 +716,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/splom/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/splom/marker/__init__.py
@@ -1302,9 +1302,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1975,9 +1975,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2225,9 +2225,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/streamtube/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/streamtube/__init__.py
@@ -2011,9 +2011,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2682,9 +2682,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2932,9 +2932,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/sunburst/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/sunburst/__init__.py
@@ -1062,10 +1062,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/sunburst/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/sunburst/marker/__init__.py
@@ -899,9 +899,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1572,9 +1572,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -1823,9 +1823,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/surface/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/surface/__init__.py
@@ -1954,9 +1954,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -2626,9 +2626,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2876,9 +2876,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/table/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/table/__init__.py
@@ -758,7 +758,7 @@ class Header(_BaseTraceHierarchyType):
         Sets the cell value formatting rule using d3 formatting mini-
         language which is similar to those of Python. See
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format
+        reference/blob/main/Formatting.md#d3_format
     
         The 'format' property is an array that may be specified as a tuple,
         list, numpy array, or pandas Series
@@ -1003,7 +1003,7 @@ class Header(_BaseTraceHierarchyType):
             Sets the cell value formatting rule using d3 formatting
             mini-language which is similar to those of Python. See
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         formatsrc
             Sets the source reference on plot.ly for  format .
         height
@@ -1074,7 +1074,7 @@ class Header(_BaseTraceHierarchyType):
             Sets the cell value formatting rule using d3 formatting
             mini-language which is similar to those of Python. See
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         formatsrc
             Sets the source reference on plot.ly for  format .
         height
@@ -1535,7 +1535,7 @@ class Cells(_BaseTraceHierarchyType):
         Sets the cell value formatting rule using d3 formatting mini-
         language which is similar to those of Python. See
         https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format
+        reference/blob/main/Formatting.md#d3_format
     
         The 'format' property is an array that may be specified as a tuple,
         list, numpy array, or pandas Series
@@ -1780,7 +1780,7 @@ class Cells(_BaseTraceHierarchyType):
             Sets the cell value formatting rule using d3 formatting
             mini-language which is similar to those of Python. See
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         formatsrc
             Sets the source reference on plot.ly for  format .
         height
@@ -1851,7 +1851,7 @@ class Cells(_BaseTraceHierarchyType):
             Sets the cell value formatting rule using d3 formatting
             mini-language which is similar to those of Python. See
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format
+            reference/blob/main/Formatting.md#d3_format
         formatsrc
             Sets the source reference on plot.ly for  format .
         height

--- a/env/Lib/site-packages/plotly/graph_objs/treemap/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/treemap/__init__.py
@@ -1562,10 +1562,10 @@ class Marker(_BaseTraceHierarchyType):
                     formatting mini-languages which are very
                     similar to those in Python. For numbers, see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Formatting.md#d3_format
+                    reference/blob/main/Formatting.md#d3_format
                     And for dates see:
                     https://github.com/d3/d3-3.x-api-
-                    reference/blob/master/Time-Formatting.md#format
+                    reference/blob/main/Time-Formatting.md#format
                     We add one item to d3's date formatter: "%{n}f"
                     for fractional seconds with n digits. For
                     example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/graph_objs/treemap/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/treemap/marker/__init__.py
@@ -1081,9 +1081,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -1754,9 +1754,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -2005,9 +2005,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/graph_objs/volume/__init__.py
+++ b/env/Lib/site-packages/plotly/graph_objs/volume/__init__.py
@@ -2550,9 +2550,9 @@ class ColorBar(_BaseTraceHierarchyType):
         Sets the tick label formatting rule using d3 formatting mini-
         languages which are very similar to those in Python. For
         numbers, see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Formatting.md#d3_format And for dates
+        reference/blob/main/Formatting.md#d3_format And for dates
         see: https://github.com/d3/d3-3.x-api-
-        reference/blob/master/Time-Formatting.md#format We add one item
+        reference/blob/main/Time-Formatting.md#format We add one item
         to d3's date formatter: "%{n}f" for fractional seconds with n
         digits. For example, *2016-10-13 09:15:23.456* with tickformat
         "%H~%M~%S.%2f" would display "09~15~23.46"
@@ -3222,9 +3222,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would
@@ -3472,9 +3472,9 @@ class ColorBar(_BaseTraceHierarchyType):
             mini-languages which are very similar to those in
             Python. For numbers, see:
             https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Formatting.md#d3_format And for
+            reference/blob/main/Formatting.md#d3_format And for
             dates see: https://github.com/d3/d3-3.x-api-
-            reference/blob/master/Time-Formatting.md#format We add
+            reference/blob/main/Time-Formatting.md#format We add
             one item to d3's date formatter: "%{n}f" for fractional
             seconds with n digits. For example, *2016-10-13
             09:15:23.456* with tickformat "%H~%M~%S.%2f" would

--- a/env/Lib/site-packages/plotly/validators/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/__init__.py
@@ -549,13 +549,13 @@ class WaterfallValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -718,13 +718,13 @@ class WaterfallValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -912,13 +912,13 @@ class VolumeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -1154,13 +1154,13 @@ class ViolinValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -1457,13 +1457,13 @@ class TreemapValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -1587,13 +1587,13 @@ class TreemapValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -1882,13 +1882,13 @@ class SurfaceValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -2098,13 +2098,13 @@ class SunburstValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -2226,13 +2226,13 @@ class SunburstValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -2382,13 +2382,13 @@ class StreamtubeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -2599,13 +2599,13 @@ class SplomValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -2857,13 +2857,13 @@ class ScatterternaryValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -2996,13 +2996,13 @@ class ScatterternaryValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -3133,13 +3133,13 @@ class ScatterpolarglValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -3273,13 +3273,13 @@ class ScatterpolarglValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -3422,13 +3422,13 @@ class ScatterpolarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -3562,13 +3562,13 @@ class ScatterpolarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -3693,13 +3693,13 @@ class ScattermapboxValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -3834,13 +3834,13 @@ class ScattermapboxValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -3977,13 +3977,13 @@ class ScatterglValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -4098,13 +4098,13 @@ class ScatterglValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -4250,13 +4250,13 @@ class ScattergeoValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -4400,13 +4400,13 @@ class ScattergeoValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -4537,13 +4537,13 @@ class ScattercarpetValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -4663,13 +4663,13 @@ class ScattercarpetValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -4784,13 +4784,13 @@ class Scatter3dValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -4916,13 +4916,13 @@ class Scatter3dValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -5104,13 +5104,13 @@ class ScatterValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -5280,13 +5280,13 @@ class ScatterValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -5493,7 +5493,7 @@ class SankeyValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-language which is similar to
                 those of Python. See
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
             valuesuffix
                 Adds a unit to follow the value in the hover
                 tooltip. Add a space if a separation is
@@ -5748,13 +5748,13 @@ class PieValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -5892,13 +5892,13 @@ class PieValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -6150,13 +6150,13 @@ class ParcatsValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -6565,13 +6565,13 @@ class Mesh3dValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -6886,13 +6886,13 @@ class IsosurfaceValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -7215,13 +7215,13 @@ class ImageValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -7486,13 +7486,13 @@ class Histogram2dContourValidator(_plotly_utils.basevalidators.CompoundValidator
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -7674,7 +7674,7 @@ class Histogram2dContourValidator(_plotly_utils.basevalidators.CompoundValidator
                 formatting mini-languages which are very
                 similar to those in Python. See:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
             zmax
                 Sets the upper bound of the color domain. Value
                 should have the same units as in `z` and if
@@ -7817,13 +7817,13 @@ class Histogram2dValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -7994,7 +7994,7 @@ class Histogram2dValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. See:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
             zmax
                 Sets the upper bound of the color domain. Value
                 should have the same units as in `z` and if
@@ -8127,13 +8127,13 @@ class HistogramValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -8626,13 +8626,13 @@ class HeatmapValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -8797,7 +8797,7 @@ class HeatmapValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. See:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
             zmax
                 Sets the upper bound of the color domain. Value
                 should have the same units as in `z` and if
@@ -8876,13 +8876,13 @@ class FunnelareaValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -9002,13 +9002,13 @@ class FunnelareaValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -9129,13 +9129,13 @@ class FunnelValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -9290,13 +9290,13 @@ class FunnelValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are
@@ -9456,13 +9456,13 @@ class DensitymapboxValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -9983,13 +9983,13 @@ class ContourValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -10165,7 +10165,7 @@ class ContourValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. See:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
             zmax
                 Sets the upper bound of the color domain. Value
                 should have the same units as in `z` and if
@@ -10289,13 +10289,13 @@ class ConeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -10559,13 +10559,13 @@ class ChoroplethmapboxValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -10804,13 +10804,13 @@ class ChoroplethValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -11378,13 +11378,13 @@ class BoxValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -11645,13 +11645,13 @@ class BarpolarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -11891,13 +11891,13 @@ class BarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -12060,13 +12060,13 @@ class BarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax.
                 Every attributes that can be specified per-
                 point (the ones that are `arrayOk: true`) are

--- a/env/Lib/site-packages/plotly/validators/bar/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/bar/marker/__init__.py
@@ -320,10 +320,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/barpolar/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/barpolar/marker/__init__.py
@@ -328,10 +328,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/carpet/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/carpet/__init__.py
@@ -560,7 +560,7 @@ class BaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:  We add one item to d3's
                 date formatter: "%{n}f" for fractional seconds
                 with n digits. For example, *2016-10-13
@@ -831,7 +831,7 @@ class AaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:  We add one item to d3's
                 date formatter: "%{n}f" for fractional seconds
                 with n digits. For example, *2016-10-13

--- a/env/Lib/site-packages/plotly/validators/choropleth/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/choropleth/__init__.py
@@ -741,10 +741,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/choroplethmapbox/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/choroplethmapbox/__init__.py
@@ -776,10 +776,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/cone/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/cone/__init__.py
@@ -809,10 +809,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/contour/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/contour/__init__.py
@@ -884,7 +884,7 @@ class ContoursValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-language which is very similar
                 to Python, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
             operation
                 Sets the constraint operation. "=" keeps
                 regions equal to `value` "<" and "<=" keep
@@ -1089,10 +1089,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/contourcarpet/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/contourcarpet/__init__.py
@@ -561,7 +561,7 @@ class ContoursValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-language which is very similar
                 to Python, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
             operation
                 Sets the constraint operation. "=" keeps
                 regions equal to `value` "<" and "<=" keep
@@ -752,10 +752,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/densitymapbox/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/densitymapbox/__init__.py
@@ -726,10 +726,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/funnel/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/funnel/marker/__init__.py
@@ -322,10 +322,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/heatmap/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/heatmap/__init__.py
@@ -960,10 +960,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/heatmapgl/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/heatmapgl/__init__.py
@@ -746,10 +746,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/histogram/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/histogram/marker/__init__.py
@@ -332,10 +332,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/histogram2d/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/histogram2d/__init__.py
@@ -994,10 +994,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/histogram2dcontour/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/histogram2dcontour/__init__.py
@@ -966,7 +966,7 @@ class ContoursValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-language which is very similar
                 to Python, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
             operation
                 Sets the constraint operation. "=" keeps
                 regions equal to `value` "<" and "<=" keep
@@ -1161,10 +1161,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/indicator/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/indicator/__init__.py
@@ -133,7 +133,7 @@ class NumberValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-language which is similar to
                 those of Python. See
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
 """,
             ),
             **kwargs
@@ -336,7 +336,7 @@ class DeltaValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-language which is similar to
                 those of Python. See
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
 """,
             ),
             **kwargs

--- a/env/Lib/site-packages/plotly/validators/indicator/gauge/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/indicator/gauge/__init__.py
@@ -283,10 +283,10 @@ class AxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/isosurface/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/isosurface/__init__.py
@@ -892,10 +892,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/layout/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/layout/__init__.py
@@ -133,10 +133,10 @@ class YAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -327,10 +327,10 @@ class YAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -563,10 +563,10 @@ class XAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -763,10 +763,10 @@ class XAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/layout/coloraxis/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/layout/coloraxis/__init__.py
@@ -177,10 +177,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/layout/polar/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/layout/polar/__init__.py
@@ -140,10 +140,10 @@ class RadialAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -241,10 +241,10 @@ class RadialAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -528,10 +528,10 @@ class AngularAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -623,10 +623,10 @@ class AngularAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/layout/scene/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/layout/scene/__init__.py
@@ -100,10 +100,10 @@ class ZAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -214,10 +214,10 @@ class ZAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -406,10 +406,10 @@ class YAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -520,10 +520,10 @@ class YAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -712,10 +712,10 @@ class XAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -826,10 +826,10 @@ class XAxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/layout/ternary/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/layout/ternary/__init__.py
@@ -122,10 +122,10 @@ class CaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -206,10 +206,10 @@ class CaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -359,10 +359,10 @@ class BaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -443,10 +443,10 @@ class BaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -582,10 +582,10 @@ class AaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with
@@ -666,10 +666,10 @@ class AaxisValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/mesh3d/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/mesh3d/__init__.py
@@ -1020,10 +1020,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/parcats/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/parcats/__init__.py
@@ -260,13 +260,13 @@ class LineValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this

--- a/env/Lib/site-packages/plotly/validators/parcats/line/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/parcats/line/__init__.py
@@ -216,10 +216,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/parcoords/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/parcoords/__init__.py
@@ -491,10 +491,10 @@ class DimensionsValidator(_plotly_utils.basevalidators.CompoundArrayValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/parcoords/line/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/parcoords/line/__init__.py
@@ -187,10 +187,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/sankey/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/sankey/__init__.py
@@ -208,13 +208,13 @@ class NodeValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this
@@ -348,13 +348,13 @@ class LinkValidator(_plotly_utils.basevalidators.CompoundValidator):
                 syntax %{variable:d3-format}, for example
                 "Price: %{y:$.2f}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 for details on the formatting syntax. Dates are
                 formatted using d3-time-format's syntax
                 %{variable|d3-time-format}, for example "Day:
                 %{2019-01-01|%A}".
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 for details on the date formatting syntax. The
                 variables available in `hovertemplate` are the
                 ones emitted as event data described at this

--- a/env/Lib/site-packages/plotly/validators/scatter/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/scatter/marker/__init__.py
@@ -768,10 +768,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/scatter3d/line/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/scatter3d/line/__init__.py
@@ -219,10 +219,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/scatter3d/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/scatter3d/marker/__init__.py
@@ -433,10 +433,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/scattercarpet/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/scattercarpet/marker/__init__.py
@@ -792,10 +792,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/scattergeo/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/scattergeo/marker/__init__.py
@@ -769,10 +769,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/scattergl/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/scattergl/marker/__init__.py
@@ -728,10 +728,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/scattermapbox/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/scattermapbox/marker/__init__.py
@@ -345,10 +345,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/scatterpolar/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/scatterpolar/marker/__init__.py
@@ -788,10 +788,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/scatterpolargl/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/scatterpolargl/marker/__init__.py
@@ -742,10 +742,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/scatterternary/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/scatterternary/marker/__init__.py
@@ -792,10 +792,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/splom/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/splom/marker/__init__.py
@@ -714,10 +714,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/streamtube/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/streamtube/__init__.py
@@ -815,10 +815,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/sunburst/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/sunburst/marker/__init__.py
@@ -235,10 +235,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/surface/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/surface/__init__.py
@@ -875,10 +875,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/table/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/table/__init__.py
@@ -256,7 +256,7 @@ class HeaderValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-language which is similar to
                 those of Python. See
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
             formatsrc
                 Sets the source reference on plot.ly for
                 format .
@@ -439,7 +439,7 @@ class CellsValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-language which is similar to
                 those of Python. See
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
             formatsrc
                 Sets the source reference on plot.ly for
                 format .

--- a/env/Lib/site-packages/plotly/validators/treemap/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/treemap/__init__.py
@@ -95,7 +95,7 @@ class TilingValidator(_plotly_utils.basevalidators.CompoundValidator):
             squarifyratio
                 When using "squarify" `packing` algorithm,
                 according to https://github.com/d3/d3-hierarchy
-                /blob/master/README.md#squarify_ratio this
+                /blob/main/README.md#squarify_ratio this
                 option specifies the desired aspect ratio of
                 the generated rectangles. The ratio must be
                 specified as a number greater than or equal to

--- a/env/Lib/site-packages/plotly/validators/treemap/marker/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/treemap/marker/__init__.py
@@ -272,10 +272,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/plotly/validators/volume/__init__.py
+++ b/env/Lib/site-packages/plotly/validators/volume/__init__.py
@@ -902,10 +902,10 @@ class ColorBarValidator(_plotly_utils.basevalidators.CompoundValidator):
                 formatting mini-languages which are very
                 similar to those in Python. For numbers, see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Formatting.md#d3_format
+                reference/blob/main/Formatting.md#d3_format
                 And for dates see:
                 https://github.com/d3/d3-3.x-api-
-                reference/blob/master/Time-Formatting.md#format
+                reference/blob/main/Time-Formatting.md#format
                 We add one item to d3's date formatter: "%{n}f"
                 for fractional seconds with n digits. For
                 example, *2016-10-13 09:15:23.456* with

--- a/env/Lib/site-packages/pycparser/ply/lex.py
+++ b/env/Lib/site-packages/pycparser/ply/lex.py
@@ -114,12 +114,12 @@ class NullLogger(object):
 
 class Lexer:
     def __init__(self):
-        self.lexre = None             # Master regular expression. This is a list of
+        self.lexre = None             # Main regular expression. This is a list of
                                       # tuples (re, findex) where re is a compiled
                                       # regular expression and findex is a list
                                       # mapping regex group numbers to rules
         self.lexretext = None         # Current regular expression strings
-        self.lexstatere = {}          # Dictionary mapping lexer states to master regexs
+        self.lexstatere = {}          # Dictionary mapping lexer states to main regexs
         self.lexstateretext = {}      # Dictionary mapping lexer states to regex strings
         self.lexstaterenames = {}     # Dictionary mapping lexer states to symbol names
         self.lexstate = 'INITIAL'     # Current lexer state
@@ -484,13 +484,13 @@ def _names_to_funcs(namelist, fdict):
     return result
 
 # -----------------------------------------------------------------------------
-# _form_master_re()
+# _form_main_re()
 #
 # This function takes a list of all of the regex components and attempts to
-# form the master regular expression.  Given limitations in the Python re
-# module, it may be necessary to break the master regex into separate expressions.
+# form the main regular expression.  Given limitations in the Python re
+# module, it may be necessary to break the main regex into separate expressions.
 # -----------------------------------------------------------------------------
-def _form_master_re(relist, reflags, ldict, toknames):
+def _form_main_re(relist, reflags, ldict, toknames):
     if not relist:
         return []
     regex = '|'.join(relist)
@@ -518,8 +518,8 @@ def _form_master_re(relist, reflags, ldict, toknames):
         m = int(len(relist)/2)
         if m == 0:
             m = 1
-        llist, lre, lnames = _form_master_re(relist[:m], reflags, ldict, toknames)
-        rlist, rre, rnames = _form_master_re(relist[m:], reflags, ldict, toknames)
+        llist, lre, lnames = _form_main_re(relist[:m], reflags, ldict, toknames)
+        rlist, rre, rnames = _form_main_re(relist[m:], reflags, ldict, toknames)
         return (llist+rlist), (lre+rre), (lnames+rnames)
 
 # -----------------------------------------------------------------------------
@@ -943,7 +943,7 @@ def lex(module=None, object=None, debug=False, optimize=False, lextab='lextab',
     stateinfo = linfo.stateinfo
 
     regexs = {}
-    # Build the master regular expressions
+    # Build the main regular expressions
     for state in stateinfo:
         regex_list = []
 
@@ -963,13 +963,13 @@ def lex(module=None, object=None, debug=False, optimize=False, lextab='lextab',
 
         regexs[state] = regex_list
 
-    # Build the master regular expressions
+    # Build the main regular expressions
 
     if debug:
         debuglog.info('lex: ==== MASTER REGEXS FOLLOW ====')
 
     for state in regexs:
-        lexre, re_text, re_names = _form_master_re(regexs[state], reflags, ldict, linfo.toknames)
+        lexre, re_text, re_names = _form_main_re(regexs[state], reflags, ldict, linfo.toknames)
         lexobj.lexstatere[state] = lexre
         lexobj.lexstateretext[state] = re_text
         lexobj.lexstaterenames[state] = re_names

--- a/env/Lib/site-packages/setuptools/command/easy_install.py
+++ b/env/Lib/site-packages/setuptools/command/easy_install.py
@@ -1781,7 +1781,7 @@ def update_dist_caches(dist_path, fix_zipimporter_caches):
     # There are several other known sources of stale zipimport.zipimporter
     # instances that we do not clear here, but might if ever given a reason to
     # do so:
-    # * Global setuptools pkg_resources.working_set (a.k.a. 'master working
+    # * Global setuptools pkg_resources.working_set (a.k.a. 'main working
     # set') may contain distributions which may in turn contain their
     #   zipimport.zipimporter loaders.
     # * Several zipimport.zipimporter loaders held by local variables further

--- a/env/Lib/site-packages/textblob/en/inflect.py
+++ b/env/Lib/site-packages/textblob/en/inflect.py
@@ -230,8 +230,8 @@ plural_categories = {
         "generalissimo", "ghetto", "guano", "inferno", "jumbo", "lingo", "lumbago", "magneto",
         "manifesto", "medico", "octavo", "photo", "pro", "quarto", "rhino", "stylo"],
     "general-generals": [
-        "Adjutant", "Brigadier", "Lieutenant", "Major", "Quartermaster",
-        "adjutant", "brigadier", "lieutenant", "major", "quartermaster"],
+        "Adjutant", "Brigadier", "Lieutenant", "Major", "Quartermain",
+        "adjutant", "brigadier", "lieutenant", "major", "quartermain"],
 }
 
 def pluralize(word, pos=NOUN, custom={}, classical=True):
@@ -257,7 +257,7 @@ def pluralize(word, pos=NOUN, custom={}, classical=True):
             return owners + "'s"
 
     # Recursion of compound words
-    # (Postmasters General, mothers-in-law, Roman deities).
+    # (Postmains General, mothers-in-law, Roman deities).
     words = word.replace("-", " ").split(" ")
     if len(words) > 1:
         if words[1] == "general" or words[1] == "General" and \


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.